### PR TITLE
Aggregate watch channels data

### DIFF
--- a/docs/design-proposals/apiserver/Action-API-design.md
+++ b/docs/design-proposals/apiserver/Action-API-design.md
@@ -333,7 +333,7 @@ the actions as illustrated below:
 ```
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
 func NewSourceApiserver(c clientset.Interface, nodeName types.NodeName, updates chan<- interface{}) {
-        lwActions := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "actions", metav1.NamespaceAll, fields.Everything())
+        lwActions := cache.NewListWatchFromClient(c.CoreV1(), "actions", metav1.NamespaceAll, fields.Everything())
         newSourceApiserverFromLWActions(lwActions, updates)
 }
 

--- a/pkg/client/tests/listwatch_test.go
+++ b/pkg/client/tests/listwatch_test.go
@@ -108,7 +108,7 @@ func TestListWatchesCanList(t *testing.T) {
 		kubeConfig := restclient.KubeConfig{Host: server.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}}
 		configs := restclient.NewAggregatedConfig(&kubeConfig)
 		client := clientset.NewForConfigOrDie(configs)
-		lw := NewListWatchFromClient(client.CoreV1().RESTClient(), item.resource, item.namespace, item.fieldSelector)
+		lw := NewListWatchFromClient(client.CoreV1(), item.resource, item.namespace, item.fieldSelector)
 		lw.DisableChunking = true
 		// This test merely tests that the correct request is made.
 		lw.List(metav1.ListOptions{})
@@ -177,7 +177,7 @@ func TestListWatchesCanWatch(t *testing.T) {
 		kubeConfig := &restclient.KubeConfig{Host: server.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}}
 		configs := restclient.NewAggregatedConfig(kubeConfig)
 		client := clientset.NewForConfigOrDie(configs)
-		lw := NewListWatchFromClient(client.CoreV1().RESTClient(), item.resource, item.namespace, item.fieldSelector)
+		lw := NewListWatchFromClient(client.CoreV1(), item.resource, item.namespace, item.fieldSelector)
 		// This test merely tests that the correct request is made.
 		lw.Watch(metav1.ListOptions{ResourceVersion: item.rv})
 		handler.ValidateRequest(t, item.location, "GET", nil)
@@ -186,15 +186,15 @@ func TestListWatchesCanWatch(t *testing.T) {
 
 type lw struct {
 	list  runtime.Object
-	watch watch.Interface
+	watch watch.AggregatedWatchInterface
 }
 
 func (w lw) List(options metav1.ListOptions) (runtime.Object, error) {
 	return w.list, nil
 }
 
-func (w lw) Watch(options metav1.ListOptions) (watch.Interface, error) {
-	return w.watch, nil
+func (w lw) Watch(options metav1.ListOptions) watch.AggregatedWatchInterface {
+	return w.watch
 }
 
 func (w lw) Update(options metav1.ListOptions) {

--- a/pkg/cloudfabric-controller/client_builder.go
+++ b/pkg/cloudfabric-controller/client_builder.go
@@ -122,7 +122,7 @@ func (b SAControllerClientBuilder) Config(name string) (*restclient.Config, erro
 			options.FieldSelector = fieldSelector
 			return b.CoreClient.Secrets(b.Namespace).List(options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			options.FieldSelector = fieldSelector
 			return b.CoreClient.Secrets(b.Namespace).Watch(options)
 		},

--- a/pkg/controller/client_builder.go
+++ b/pkg/controller/client_builder.go
@@ -123,7 +123,7 @@ func (b SAControllerClientBuilder) Config(name string) (*restclient.Config, erro
 			options.FieldSelector = fieldSelector
 			return b.CoreClient.Secrets(b.Namespace).List(options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			options.FieldSelector = fieldSelector
 			return b.CoreClient.Secrets(b.Namespace).Watch(options)
 		},

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -239,9 +239,9 @@ func (c conversionClient) List(opts metav1.ListOptions) (*apps.ReplicaSetList, e
 	return convertList(rcList)
 }
 
-func (c conversionClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c conversionClient) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	// This is not used by RSC because we wrap the shared informer instead.
-	return nil, errors.New("Watch() is not implemented for conversionClient")
+	return watch.CreateNilWatcherWithError(errors.New("Watch() is not implemented for conversionClient"))
 }
 
 func (c conversionClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *apps.ReplicaSet, err error) {

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -195,7 +195,7 @@ func (o *RolloutStatusOptions) Run() error {
 			options.FieldSelector = fieldSelector
 			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			options.FieldSelector = fieldSelector
 			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(options)
 		},

--- a/pkg/kubectl/cmd/run/run.go
+++ b/pkg/kubectl/cmd/run/run.go
@@ -517,7 +517,7 @@ func waitForPod(podClient corev1client.PodsGetter, ns, name string, exitConditio
 			options.FieldSelector = fieldSelector
 			return podClient.Pods(ns).List(options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			options.FieldSelector = fieldSelector
 			return podClient.Pods(ns).Watch(options)
 		},

--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -292,8 +292,8 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 		watchOptions := metav1.ListOptions{}
 		watchOptions.FieldSelector = nameSelector
 		watchOptions.ResourceVersion = gottenObjList.GetResourceVersion()
-		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).NamespaceWithMultiTenancy(info.Namespace, info.Tenant).Watch(watchOptions)
-		if err != nil {
+		objWatch := o.DynamicClient.Resource(info.Mapping.Resource).NamespaceWithMultiTenancy(info.Namespace, info.Tenant).Watch(watchOptions)
+		if objWatch.GetFirstError() != nil {
 			return gottenObj, false, err
 		}
 
@@ -387,8 +387,8 @@ func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (ru
 		watchOptions := metav1.ListOptions{}
 		watchOptions.FieldSelector = nameSelector
 		watchOptions.ResourceVersion = resourceVersion
-		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).NamespaceWithMultiTenancy(info.Namespace, info.Tenant).Watch(watchOptions)
-		if err != nil {
+		objWatch := o.DynamicClient.Resource(info.Mapping.Resource).NamespaceWithMultiTenancy(info.Namespace, info.Tenant).Watch(watchOptions)
+		if objWatch.GetFirstError() != nil {
 			return gottenObj, false, err
 		}
 

--- a/pkg/kubectl/polymorphichelpers/helpers.go
+++ b/pkg/kubectl/polymorphichelpers/helpers.go
@@ -58,8 +58,8 @@ func GetFirstPod(client coreclient.PodsGetter, tenant, namespace string, selecto
 
 	// Watch until we observe a pod
 	options.ResourceVersion = podList.ResourceVersion
-	w, err := client.PodsWithMultiTenancy(namespace, tenant).Watch(options)
-	if err != nil {
+	w := client.PodsWithMultiTenancy(namespace, tenant).Watch(options)
+	if w.GetFirstError() != nil {
 		return nil, 0, err
 	}
 	defer w.Stop()

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -32,10 +32,10 @@ import (
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
 func NewSourceApiserver(c clientset.Interface, nodeName types.NodeName, updates chan<- interface{}) {
-	lw := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector(api.PodHostField, string(nodeName)))
+	lw := cache.NewListWatchFromClient(c.CoreV1(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector(api.PodHostField, string(nodeName)))
 	newSourceApiserverFromLW(lw, updates)
 
-	lwActions := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "actions", metav1.NamespaceAll,
+	lwActions := cache.NewListWatchFromClient(c.CoreV1(), "actions", metav1.NamespaceAll,
 		fields.OneTermEqualSelector(api.PodHostField, string(nodeName)))
 	newSourceApiserverFromLWActions(lwActions, updates)
 }

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -138,7 +138,7 @@ func NewWatchingConfigMapManager(kubeClient clientset.Interface) Manager {
 	listConfigMap := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).List(opts)
 	}
-	watchConfigMap := func(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	watchConfigMap := func(namespace string, opts metav1.ListOptions) watch.AggregatedWatchInterface {
 		return kubeClient.CoreV1().ConfigMaps(namespace).Watch(opts)
 	}
 	newConfigMap := func() runtime.Object {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -429,7 +429,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	serviceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	if kubeDeps.KubeClient != nil {
-		serviceLW := cache.NewListWatchFromClient(kubeDeps.KubeClient.CoreV1().RESTClient(), "services", metav1.NamespaceAll, fields.Everything())
+		serviceLW := cache.NewListWatchFromClient(kubeDeps.KubeClient.CoreV1(), "services", metav1.NamespaceAll, fields.Everything())
 		r := cache.NewReflector(serviceLW, &v1.Service{}, serviceIndexer, 0)
 		go r.Run(wait.NeverStop)
 	}
@@ -438,7 +438,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	if kubeDeps.KubeClient != nil {
 		fieldSelector := fields.Set{api.ObjectNameField: string(nodeName)}.AsSelector()
-		nodeLW := cache.NewListWatchFromClient(kubeDeps.KubeClient.CoreV1().RESTClient(), "nodes", metav1.NamespaceAll, fieldSelector)
+		nodeLW := cache.NewListWatchFromClient(kubeDeps.KubeClient.CoreV1(), "nodes", metav1.NamespaceAll, fieldSelector)
 		r := cache.NewReflector(nodeLW, &v1.Node{}, nodeIndexer, 0)
 		go r.Run(wait.NeverStop)
 	}

--- a/pkg/kubelet/kubeletconfig/checkpoint/download.go
+++ b/pkg/kubelet/kubeletconfig/checkpoint/download.go
@@ -225,7 +225,7 @@ func (r *remoteConfigMap) Informer(client clientset.Interface, handler cache.Res
 				FieldSelector: fieldselector.String(),
 			})
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			return client.CoreV1().ConfigMaps(r.source.ConfigMap.Namespace).Watch(metav1.ListOptions{
 				FieldSelector:   fieldselector.String(),
 				ResourceVersion: options.ResourceVersion,

--- a/pkg/kubelet/kubeletconfig/watch.go
+++ b/pkg/kubelet/kubeletconfig/watch.go
@@ -51,7 +51,7 @@ func newSharedNodeInformer(client clientset.Interface, nodeName string,
 				FieldSelector: fieldselector.String(),
 			})
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			return client.CoreV1().Nodes().Watch(metav1.ListOptions{
 				FieldSelector:   fieldselector.String(),
 				ResourceVersion: options.ResourceVersion,

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -138,7 +138,7 @@ func NewWatchingSecretManager(kubeClient clientset.Interface) Manager {
 	listSecret := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().Secrets(namespace).List(opts)
 	}
-	watchSecret := func(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	watchSecret := func(namespace string, opts metav1.ListOptions) watch.AggregatedWatchInterface {
 		return kubeClient.CoreV1().Secrets(namespace).Watch(opts)
 	}
 	newSecret := func() runtime.Object {

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -42,7 +42,7 @@ import (
 )
 
 type listObjectFunc func(string, metav1.ListOptions) (runtime.Object, error)
-type watchObjectFunc func(string, metav1.ListOptions) (watch.Interface, error)
+type watchObjectFunc func(string, metav1.ListOptions) watch.AggregatedWatchInterface
 type newObjectFunc func() runtime.Object
 
 // objectCacheItem is a single item stored in objectCache.
@@ -91,7 +91,7 @@ func (c *objectCache) newReflector(namespace, name string) *objectCacheItem {
 		options.FieldSelector = fieldSelector
 		return c.listObject(namespace, options)
 	}
-	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
+	watchFunc := func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 		options.FieldSelector = fieldSelector
 		return c.watchObject(namespace, options)
 	}

--- a/pkg/kubemark/controller.go
+++ b/pkg/kubemark/controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -391,11 +392,11 @@ func (kubemarkCluster *kubemarkCluster) markNodeForDeletion(name string) {
 }
 
 func newReplicationControllerInformer(kubeClient kubeclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	rcListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "replicationcontrollers", namespaceKubemark, fields.Everything())
+	rcListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1(), "replicationcontrollers", namespaceKubemark, fields.Everything())
 	return cache.NewSharedIndexInformer(rcListWatch, &apiv1.ReplicationController{}, resyncPeriod, nil)
 }
 
 func newPodInformer(kubeClient kubeclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", namespaceKubemark, fields.Everything())
+	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1(), "pods", namespaceKubemark, fields.Everything())
 	return cache.NewSharedIndexInformer(podListWatch, &apiv1.Pod{}, resyncPeriod, nil)
 }

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -654,7 +654,7 @@ func NewPodInformer(client clientset.Interface, resyncPeriod time.Duration) core
 	selector := fields.ParseSelectorOrDie(
 		"status.phase!=" + string(v1.PodSucceeded) +
 			",status.phase!=" + string(v1.PodFailed))
-	lw := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), string(v1.ResourcePods), metav1.NamespaceAll, selector)
+	lw := cache.NewListWatchFromClient(client.CoreV1(), string(v1.ResourcePods), metav1.NamespaceAll, selector)
 	return &podInformer{
 		informer: cache.NewSharedIndexInformer(lw, &v1.Pod{}, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
 	}

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -165,8 +165,8 @@ func (c *csiAttacher) waitForVolumeAttachmentInternal(volumeHandle, attachID str
 		return attachID, nil
 	}
 
-	watcher, err := c.k8s.StorageV1().VolumeAttachments().Watch(meta.SingleObject(meta.ObjectMeta{Name: attachID, ResourceVersion: attach.ResourceVersion}))
-	if err != nil {
+	watcher := c.k8s.StorageV1().VolumeAttachments().Watch(meta.SingleObject(meta.ObjectMeta{Name: attachID, ResourceVersion: attach.ResourceVersion}))
+	if watcher.GetFirstError() != nil {
 		return "", fmt.Errorf("watch error:%v for volume %v", err, volumeHandle)
 	}
 	var watcherClosed bool
@@ -488,8 +488,8 @@ func (c *csiAttacher) waitForVolumeDetachmentInternal(volumeHandle, attachID str
 		return errors.New(detachErr.Message)
 	}
 
-	watcher, err := c.k8s.StorageV1().VolumeAttachments().Watch(meta.SingleObject(meta.ObjectMeta{Name: attachID, ResourceVersion: attach.ResourceVersion}))
-	if err != nil {
+	watcher := c.k8s.StorageV1().VolumeAttachments().Watch(meta.SingleObject(meta.ObjectMeta{Name: attachID, ResourceVersion: attach.ResourceVersion}))
+	if watcher.GetFirstError() != nil {
 		return fmt.Errorf("watch error:%v for volume %v", err, volumeHandle)
 	}
 	ch := watcher.ResultChan()

--- a/pkg/volume/util/recyclerclient/recycler_client.go
+++ b/pkg/volume/util/recyclerclient/recycler_client.go
@@ -204,17 +204,17 @@ func (c *realRecyclerClient) WatchPod(name, namespace string, stopChannel chan s
 		Watch:         true,
 	}
 
-	podWatch, err := c.client.CoreV1().Pods(namespace).Watch(options)
-	if err != nil {
+	podWatch := c.client.CoreV1().Pods(namespace).Watch(options)
+	if podWatch.GetFirstError() != nil {
 		return nil, err
 	}
 
 	eventSelector, _ := fields.ParseSelector("involvedObject.name=" + name)
-	eventWatch, err := c.client.CoreV1().Events(namespace).Watch(metav1.ListOptions{
+	eventWatch := c.client.CoreV1().Events(namespace).Watch(metav1.ListOptions{
 		FieldSelector: eventSelector.String(),
 		Watch:         true,
 	})
-	if err != nil {
+	if eventWatch.GetFirstError() != nil {
 		podWatch.Stop()
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -45,16 +45,17 @@ type ExampleInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.Example, error)
 	List(opts metav1.ListOptions) (*v1.ExampleList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Example, err error)
 	ExampleExpansion
 }
 
 // examples implements ExampleInterface
 type examples struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newExamples returns a Examples
@@ -64,9 +65,10 @@ func newExamples(c *CrV1Client, namespace string) *examples {
 
 func newExamplesWithMultiTenancy(c *CrV1Client, namespace string, tenant string) *examples {
 	return &examples{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *examples) List(opts metav1.ListOptions) (result *v1.ExampleList, err er
 }
 
 // Watch returns a watch.Interface that watches the requested examples.
-func (c *examples) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *examples) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("examples").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("examples").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a example and creates it.  Returns the server's representation of the example, and an error, if there is any.

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_example.go
@@ -74,11 +74,14 @@ func (c *FakeExamples) List(opts v1.ListOptions) (result *crv1.ExampleList, err 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested examples.
-func (c *FakeExamples) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested examples.
+func (c *FakeExamples) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(examplesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a example and creates it.  Returns the server's representation of the example, and an error, if there is any.

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
@@ -73,7 +73,7 @@ func NewFilteredExampleInformerWithMultiTenancy(client versioned.Interface, name
 				}
 				return client.CrV1().ExamplesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -45,20 +45,22 @@ type CustomResourceDefinitionInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.CustomResourceDefinition, error)
 	List(opts v1.ListOptions) (*v1beta1.CustomResourceDefinitionList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.CustomResourceDefinition, err error)
 	CustomResourceDefinitionExpansion
 }
 
 // customResourceDefinitions implements CustomResourceDefinitionInterface
 type customResourceDefinitions struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newCustomResourceDefinitions returns a CustomResourceDefinitions
 func newCustomResourceDefinitions(c *ApiextensionsV1beta1Client) *customResourceDefinitions {
 	return &customResourceDefinitions{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -93,17 +95,22 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.C
 }
 
 // Watch returns a watch.Interface that watches the requested customResourceDefinitions.
-func (c *customResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *customResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("customresourcedefinitions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("customresourcedefinitions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
@@ -70,10 +70,13 @@ func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *v1bet
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested customResourceDefinitions.
-func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested customResourceDefinitions.
+func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(customresourcedefinitionsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
@@ -45,20 +45,22 @@ type CustomResourceDefinitionInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*apiextensions.CustomResourceDefinition, error)
 	List(opts v1.ListOptions) (*apiextensions.CustomResourceDefinitionList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *apiextensions.CustomResourceDefinition, err error)
 	CustomResourceDefinitionExpansion
 }
 
 // customResourceDefinitions implements CustomResourceDefinitionInterface
 type customResourceDefinitions struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newCustomResourceDefinitions returns a CustomResourceDefinitions
 func newCustomResourceDefinitions(c *ApiextensionsClient) *customResourceDefinitions {
 	return &customResourceDefinitions{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -93,17 +95,22 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextens
 }
 
 // Watch returns a watch.Interface that watches the requested customResourceDefinitions.
-func (c *customResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *customResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("customresourcedefinitions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("customresourcedefinitions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_customresourcedefinition.go
@@ -70,10 +70,13 @@ func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *apiex
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested customResourceDefinitions.
-func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested customResourceDefinitions.
+func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(customresourcedefinitionsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
@@ -63,7 +63,7 @@ func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, res
 				}
 				return client.ApiextensionsV1beta1().CustomResourceDefinitions().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/customresourcedefinition.go
@@ -63,7 +63,7 @@ func NewFilteredCustomResourceDefinitionInformer(client internalclientset.Interf
 				}
 				return client.Apiextensions().CustomResourceDefinitions().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
@@ -58,11 +58,11 @@ func (s *DryRunnableStorage) Delete(ctx context.Context, key string, out runtime
 	return s.Storage.Delete(ctx, key, out, preconditions, deleteValidation)
 }
 
-func (s *DryRunnableStorage) Watch(ctx context.Context, key string, resourceVersion string, p storage.SelectionPredicate) (watch.Interface, error) {
+func (s *DryRunnableStorage) Watch(ctx context.Context, key string, resourceVersion string, p storage.SelectionPredicate) watch.AggregatedWatchInterface {
 	return s.Storage.Watch(ctx, key, resourceVersion, p)
 }
 
-func (s *DryRunnableStorage) WatchList(ctx context.Context, key string, resourceVersion string, p storage.SelectionPredicate) (watch.Interface, error) {
+func (s *DryRunnableStorage) WatchList(ctx context.Context, key string, resourceVersion string, p storage.SelectionPredicate) watch.AggregatedWatchInterface {
 	return s.Storage.WatchList(ctx, key, resourceVersion, p)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1203,7 +1203,10 @@ func (e *Store) Watch(ctx context.Context, options *metainternalversion.ListOpti
 func (e *Store) WatchPredicate(ctx context.Context, p storage.SelectionPredicate, resourceVersion string) (watch.Interface, error) {
 	if name, ok := p.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
-			w, err := e.Storage.Watch(ctx, key, resourceVersion, p)
+			aw := e.Storage.Watch(ctx, key, resourceVersion, p)
+
+			// TODO - currently api server has one ETCD to watch
+			w, err := aw.GetWatcher(0)
 			if err != nil {
 				return nil, err
 			}
@@ -1216,7 +1219,8 @@ func (e *Store) WatchPredicate(ctx context.Context, p storage.SelectionPredicate
 		// optimization is skipped
 	}
 
-	w, err := e.Storage.WatchList(ctx, e.KeyRootFunc(ctx), resourceVersion, p)
+	aw := e.Storage.WatchList(ctx, e.KeyRootFunc(ctx), resourceVersion, p)
+	w, err := aw.GetWatcher(0)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -688,19 +688,21 @@ func growSlice(v reflect.Value, maxCapacity int, sizes ...int) {
 }
 
 // Watch implements storage.Interface.Watch.
-func (s *store) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (s *store) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) watch.AggregatedWatchInterface {
 	return s.watch(ctx, key, resourceVersion, pred, false)
 }
 
 // WatchList implements storage.Interface.WatchList.
-func (s *store) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (s *store) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) watch.AggregatedWatchInterface {
 	return s.watch(ctx, key, resourceVersion, pred, true)
 }
 
-func (s *store) watch(ctx context.Context, key string, rv string, pred storage.SelectionPredicate, recursive bool) (watch.Interface, error) {
+func (s *store) watch(ctx context.Context, key string, rv string, pred storage.SelectionPredicate, recursive bool) watch.AggregatedWatchInterface {
 	rev, err := s.versioner.ParseResourceVersion(rv)
 	if err != nil {
-		return nil, err
+		result := watch.NewAggregatedWatcher()
+		result.AddWatchInterface(nil, err)
+		return result
 	}
 	key = path.Join(s.pathPrefix, key)
 	return s.watcher.Watch(ctx, key, int64(rev), recursive, pred)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -107,13 +107,15 @@ func newWatcherWithPartitionConfig(client *clientv3.Client, codec runtime.Codec,
 // If recursive is false, it watches on given key.
 // If recursive is true, it watches any children and directories under the key, excluding the root key itself.
 // pred must be non-nil. Only if pred matches the change, it will be returned.
-func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bool, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bool, pred storage.SelectionPredicate) watch.AggregatedWatchInterface {
 	if recursive && !strings.HasSuffix(key, "/") {
 		key += "/"
 	}
 	wc := w.createWatchChan(ctx, key, rev, recursive, pred)
 	go wc.run()
-	return wc, nil
+	aggWc := watch.NewAggregatedWatcher()
+	aggWc.AddWatchInterface(wc, nil)
+	return aggWc
 }
 
 func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, recursive bool, pred storage.SelectionPredicate) *watchChan {

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -173,7 +173,7 @@ type Interface interface {
 	// (e.g. reconnecting without missing any updates).
 	// If resource version is "0", this interface will get current object at given key
 	// and send it in an "ADDED" event, before watch starts.
-	Watch(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) (watch.Interface, error)
+	Watch(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) watch.AggregatedWatchInterface
 
 	// WatchList begins watching the specified key's items. Items are decoded into API
 	// objects and any item selected by 'p' are sent down to returned watch.Interface.
@@ -182,7 +182,7 @@ type Interface interface {
 	// (e.g. reconnecting without missing any updates).
 	// If resource version is "0", this interface will list current objects directory defined by key
 	// and send them in "ADDED" events, before watch starts.
-	WatchList(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) (watch.Interface, error)
+	WatchList(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) watch.AggregatedWatchInterface
 
 	// Get unmarshals json found at key into objPtr. On a not found error, will either
 	// return a zero object of the requested type, or an error, depending on ignoreNotFound.

--- a/staging/src/k8s.io/client-go/dynamic/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/interface.go
@@ -37,7 +37,7 @@ type ResourceInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
 	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error)
 }
 

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -326,7 +326,7 @@ func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.Uns
 	return list, nil
 }
 
-func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	internalGV := schema.GroupVersions{
 		{Group: c.resource.Group, Version: runtime.APIVersionInternal},
 		// always include the legacy group as a decoding target to handle non-error `Status` return types
@@ -349,9 +349,14 @@ func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface,
 	}
 
 	opts.Watch = true
-	return c.getRestClient().Get().AbsPath(c.makeURLSegments("")...).
-		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		WatchWithSpecificDecoders(wrappedDecoderFn, unstructured.UnstructuredJSONScheme)
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.client.clients {
+	 	watcher, err := client.Get().AbsPath(c.makeURLSegments("")...).
+			SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+			WatchWithSpecificDecoders(wrappedDecoderFn, unstructured.UnstructuredJSONScheme)
+	 	aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {

--- a/staging/src/k8s.io/client-go/examples/workqueue/main.go
+++ b/staging/src/k8s.io/client-go/examples/workqueue/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -162,7 +163,7 @@ func main() {
 	}
 
 	// create the pod watcher
-	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", v1.NamespaceDefault, fields.Everything())
+	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1(), "pods", v1.NamespaceDefault, fields.Everything())
 
 	// create the workqueue
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -63,7 +63,7 @@ func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface
 				}
 				return client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -63,7 +63,7 @@ func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interfa
 				}
 				return client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
@@ -73,7 +73,7 @@ func NewFilteredControllerRevisionInformerWithMultiTenancy(client kubernetes.Int
 				}
 				return client.AppsV1().ControllerRevisionsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
@@ -73,7 +73,7 @@ func NewFilteredDaemonSetInformerWithMultiTenancy(client kubernetes.Interface, n
 				}
 				return client.AppsV1().DaemonSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
@@ -73,7 +73,7 @@ func NewFilteredDeploymentInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.AppsV1().DeploymentsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
@@ -73,7 +73,7 @@ func NewFilteredReplicaSetInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.AppsV1().ReplicaSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
@@ -73,7 +73,7 @@ func NewFilteredStatefulSetInformerWithMultiTenancy(client kubernetes.Interface,
 				}
 				return client.AppsV1().StatefulSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -73,7 +73,7 @@ func NewFilteredControllerRevisionInformerWithMultiTenancy(client kubernetes.Int
 				}
 				return client.AppsV1beta1().ControllerRevisionsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
@@ -73,7 +73,7 @@ func NewFilteredDeploymentInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.AppsV1beta1().DeploymentsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
@@ -73,7 +73,7 @@ func NewFilteredStatefulSetInformerWithMultiTenancy(client kubernetes.Interface,
 				}
 				return client.AppsV1beta1().StatefulSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
@@ -73,7 +73,7 @@ func NewFilteredControllerRevisionInformerWithMultiTenancy(client kubernetes.Int
 				}
 				return client.AppsV1beta2().ControllerRevisionsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
@@ -73,7 +73,7 @@ func NewFilteredDaemonSetInformerWithMultiTenancy(client kubernetes.Interface, n
 				}
 				return client.AppsV1beta2().DaemonSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
@@ -73,7 +73,7 @@ func NewFilteredDeploymentInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.AppsV1beta2().DeploymentsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
@@ -73,7 +73,7 @@ func NewFilteredReplicaSetInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.AppsV1beta2().ReplicaSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
@@ -73,7 +73,7 @@ func NewFilteredStatefulSetInformerWithMultiTenancy(client kubernetes.Interface,
 				}
 				return client.AppsV1beta2().StatefulSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/auditregistration/v1alpha1/auditsink.go
+++ b/staging/src/k8s.io/client-go/informers/auditregistration/v1alpha1/auditsink.go
@@ -72,7 +72,7 @@ func NewFilteredAuditSinkInformerWithMultiTenancy(client kubernetes.Interface, r
 				}
 				return client.AuditregistrationV1alpha1().AuditSinksWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
@@ -73,7 +73,7 @@ func NewFilteredHorizontalPodAutoscalerInformerWithMultiTenancy(client kubernete
 				}
 				return client.AutoscalingV1().HorizontalPodAutoscalersWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -73,7 +73,7 @@ func NewFilteredHorizontalPodAutoscalerInformerWithMultiTenancy(client kubernete
 				}
 				return client.AutoscalingV2beta1().HorizontalPodAutoscalersWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -73,7 +73,7 @@ func NewFilteredHorizontalPodAutoscalerInformerWithMultiTenancy(client kubernete
 				}
 				return client.AutoscalingV2beta2().HorizontalPodAutoscalersWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/job.go
@@ -73,7 +73,7 @@ func NewFilteredJobInformerWithMultiTenancy(client kubernetes.Interface, namespa
 				}
 				return client.BatchV1().JobsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
@@ -73,7 +73,7 @@ func NewFilteredCronJobInformerWithMultiTenancy(client kubernetes.Interface, nam
 				}
 				return client.BatchV1beta1().CronJobsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v2alpha1/cronjob.go
@@ -73,7 +73,7 @@ func NewFilteredCronJobInformerWithMultiTenancy(client kubernetes.Interface, nam
 				}
 				return client.BatchV2alpha1().CronJobsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
@@ -72,7 +72,7 @@ func NewFilteredCertificateSigningRequestInformerWithMultiTenancy(client kuberne
 				}
 				return client.CertificatesV1beta1().CertificateSigningRequestsWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
@@ -73,7 +73,7 @@ func NewFilteredLeaseInformerWithMultiTenancy(client kubernetes.Interface, names
 				}
 				return client.CoordinationV1().LeasesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
@@ -73,7 +73,7 @@ func NewFilteredLeaseInformerWithMultiTenancy(client kubernetes.Interface, names
 				}
 				return client.CoordinationV1beta1().LeasesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/action.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/action.go
@@ -72,7 +72,7 @@ func NewFilteredActionInformerWithMultiTenancy(client kubernetes.Interface, name
 				}
 				return client.CoreV1().ActionsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -63,7 +63,7 @@ func NewFilteredComponentStatusInformer(client kubernetes.Interface, resyncPerio
 				}
 				return client.CoreV1().ComponentStatuses().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
@@ -73,7 +73,7 @@ func NewFilteredConfigMapInformerWithMultiTenancy(client kubernetes.Interface, n
 				}
 				return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/controllerinstance.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/controllerinstance.go
@@ -62,7 +62,7 @@ func NewFilteredControllerInstanceInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.CoreV1().ControllerInstances().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -73,7 +73,7 @@ func NewFilteredEndpointsInformerWithMultiTenancy(client kubernetes.Interface, n
 				}
 				return client.CoreV1().EndpointsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/event.go
@@ -73,7 +73,7 @@ func NewFilteredEventInformerWithMultiTenancy(client kubernetes.Interface, names
 				}
 				return client.CoreV1().EventsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -73,7 +73,7 @@ func NewFilteredLimitRangeInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.CoreV1().LimitRangesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
@@ -72,7 +72,7 @@ func NewFilteredNamespaceInformerWithMultiTenancy(client kubernetes.Interface, r
 				}
 				return client.CoreV1().NamespacesWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/node.go
@@ -63,7 +63,7 @@ func NewFilteredNodeInformer(client kubernetes.Interface, resyncPeriod time.Dura
 				}
 				return client.CoreV1().Nodes().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -72,7 +72,7 @@ func NewFilteredPersistentVolumeInformerWithMultiTenancy(client kubernetes.Inter
 				}
 				return client.CoreV1().PersistentVolumesWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -73,7 +73,7 @@ func NewFilteredPersistentVolumeClaimInformerWithMultiTenancy(client kubernetes.
 				}
 				return client.CoreV1().PersistentVolumeClaimsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/pod.go
@@ -73,7 +73,7 @@ func NewFilteredPodInformerWithMultiTenancy(client kubernetes.Interface, namespa
 				}
 				return client.CoreV1().PodsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -73,7 +73,7 @@ func NewFilteredPodTemplateInformerWithMultiTenancy(client kubernetes.Interface,
 				}
 				return client.CoreV1().PodTemplatesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
@@ -73,7 +73,7 @@ func NewFilteredReplicationControllerInformerWithMultiTenancy(client kubernetes.
 				}
 				return client.CoreV1().ReplicationControllersWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -73,7 +73,7 @@ func NewFilteredResourceQuotaInformerWithMultiTenancy(client kubernetes.Interfac
 				}
 				return client.CoreV1().ResourceQuotasWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/secret.go
@@ -73,7 +73,7 @@ func NewFilteredSecretInformerWithMultiTenancy(client kubernetes.Interface, name
 				}
 				return client.CoreV1().SecretsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/service.go
@@ -73,7 +73,7 @@ func NewFilteredServiceInformerWithMultiTenancy(client kubernetes.Interface, nam
 				}
 				return client.CoreV1().ServicesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
@@ -73,7 +73,7 @@ func NewFilteredServiceAccountInformerWithMultiTenancy(client kubernetes.Interfa
 				}
 				return client.CoreV1().ServiceAccountsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/core/v1/tenant.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/tenant.go
@@ -62,7 +62,7 @@ func NewFilteredTenantInformer(client kubernetes.Interface, resyncPeriod time.Du
 				}
 				return client.CoreV1().Tenants().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
@@ -73,7 +73,7 @@ func NewFilteredEventInformerWithMultiTenancy(client kubernetes.Interface, names
 				}
 				return client.EventsV1beta1().EventsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
@@ -73,7 +73,7 @@ func NewFilteredDaemonSetInformerWithMultiTenancy(client kubernetes.Interface, n
 				}
 				return client.ExtensionsV1beta1().DaemonSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -73,7 +73,7 @@ func NewFilteredDeploymentInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.ExtensionsV1beta1().DeploymentsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -73,7 +73,7 @@ func NewFilteredIngressInformerWithMultiTenancy(client kubernetes.Interface, nam
 				}
 				return client.ExtensionsV1beta1().IngressesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
@@ -73,7 +73,7 @@ func NewFilteredNetworkPolicyInformerWithMultiTenancy(client kubernetes.Interfac
 				}
 				return client.ExtensionsV1beta1().NetworkPoliciesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/podsecuritypolicy.go
@@ -72,7 +72,7 @@ func NewFilteredPodSecurityPolicyInformerWithMultiTenancy(client kubernetes.Inte
 				}
 				return client.ExtensionsV1beta1().PodSecurityPoliciesWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -73,7 +73,7 @@ func NewFilteredReplicaSetInformerWithMultiTenancy(client kubernetes.Interface, 
 				}
 				return client.ExtensionsV1beta1().ReplicaSetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -73,7 +73,7 @@ func NewFilteredNetworkPolicyInformerWithMultiTenancy(client kubernetes.Interfac
 				}
 				return client.NetworkingV1().NetworkPoliciesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
@@ -73,7 +73,7 @@ func NewFilteredIngressInformerWithMultiTenancy(client kubernetes.Interface, nam
 				}
 				return client.NetworkingV1beta1().IngressesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
@@ -63,7 +63,7 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.NodeV1alpha1().RuntimeClasses().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
@@ -63,7 +63,7 @@ func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.NodeV1beta1().RuntimeClasses().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
@@ -73,7 +73,7 @@ func NewFilteredPodDisruptionBudgetInformerWithMultiTenancy(client kubernetes.In
 				}
 				return client.PolicyV1beta1().PodDisruptionBudgetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/podsecuritypolicy.go
@@ -72,7 +72,7 @@ func NewFilteredPodSecurityPolicyInformerWithMultiTenancy(client kubernetes.Inte
 				}
 				return client.PolicyV1beta1().PodSecurityPoliciesWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
@@ -63,7 +63,7 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.RbacV1().ClusterRoles().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
@@ -63,7 +63,7 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.RbacV1().ClusterRoleBindings().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
@@ -73,7 +73,7 @@ func NewFilteredRoleInformerWithMultiTenancy(client kubernetes.Interface, namesp
 				}
 				return client.RbacV1().RolesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
@@ -73,7 +73,7 @@ func NewFilteredRoleBindingInformerWithMultiTenancy(client kubernetes.Interface,
 				}
 				return client.RbacV1().RoleBindingsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -63,7 +63,7 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.RbacV1alpha1().ClusterRoles().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
@@ -63,7 +63,7 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.RbacV1alpha1().ClusterRoleBindings().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
@@ -73,7 +73,7 @@ func NewFilteredRoleInformerWithMultiTenancy(client kubernetes.Interface, namesp
 				}
 				return client.RbacV1alpha1().RolesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
@@ -73,7 +73,7 @@ func NewFilteredRoleBindingInformerWithMultiTenancy(client kubernetes.Interface,
 				}
 				return client.RbacV1alpha1().RoleBindingsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
@@ -63,7 +63,7 @@ func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod ti
 				}
 				return client.RbacV1beta1().ClusterRoles().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
@@ -63,7 +63,7 @@ func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPe
 				}
 				return client.RbacV1beta1().ClusterRoleBindings().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
@@ -73,7 +73,7 @@ func NewFilteredRoleInformerWithMultiTenancy(client kubernetes.Interface, namesp
 				}
 				return client.RbacV1beta1().RolesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -73,7 +73,7 @@ func NewFilteredRoleBindingInformerWithMultiTenancy(client kubernetes.Interface,
 				}
 				return client.RbacV1beta1().RoleBindingsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
@@ -63,7 +63,7 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.SchedulingV1().PriorityClasses().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
@@ -63,7 +63,7 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.SchedulingV1alpha1().PriorityClasses().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
@@ -63,7 +63,7 @@ func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod 
 				}
 				return client.SchedulingV1beta1().PriorityClasses().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/informers/settings/v1alpha1/podpreset.go
@@ -73,7 +73,7 @@ func NewFilteredPodPresetInformerWithMultiTenancy(client kubernetes.Interface, n
 				}
 				return client.SettingsV1alpha1().PodPresetsWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
@@ -63,7 +63,7 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.StorageV1().StorageClasses().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
@@ -72,7 +72,7 @@ func NewFilteredVolumeAttachmentInformerWithMultiTenancy(client kubernetes.Inter
 				}
 				return client.StorageV1().VolumeAttachmentsWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
@@ -72,7 +72,7 @@ func NewFilteredVolumeAttachmentInformerWithMultiTenancy(client kubernetes.Inter
 				}
 				return client.StorageV1alpha1().VolumeAttachmentsWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
@@ -63,7 +63,7 @@ func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time
 				}
 				return client.StorageV1beta1().CSIDrivers().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
@@ -63,7 +63,7 @@ func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.D
 				}
 				return client.StorageV1beta1().CSINodes().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -63,7 +63,7 @@ func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod t
 				}
 				return client.StorageV1beta1().StorageClasses().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
@@ -72,7 +72,7 @@ func NewFilteredVolumeAttachmentInformerWithMultiTenancy(client kubernetes.Inter
 				}
 				return client.StorageV1beta1().VolumeAttachmentsWithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_mutatingwebhookconfiguration.go
@@ -70,10 +70,13 @@ func (c *FakeMutatingWebhookConfigurations) List(opts v1.ListOptions) (result *v
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested mutatingWebhookConfigurations.
-func (c *FakeMutatingWebhookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested mutatingWebhookConfigurations.
+func (c *FakeMutatingWebhookConfigurations) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(mutatingwebhookconfigurationsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a mutatingWebhookConfiguration and creates it.  Returns the server's representation of the mutatingWebhookConfiguration, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_validatingwebhookconfiguration.go
@@ -70,10 +70,13 @@ func (c *FakeValidatingWebhookConfigurations) List(opts v1.ListOptions) (result 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested validatingWebhookConfigurations.
-func (c *FakeValidatingWebhookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested validatingWebhookConfigurations.
+func (c *FakeValidatingWebhookConfigurations) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(validatingwebhookconfigurationsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a validatingWebhookConfiguration and creates it.  Returns the server's representation of the validatingWebhookConfiguration, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -45,16 +45,17 @@ type ControllerRevisionInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.ControllerRevision, error)
 	List(opts metav1.ListOptions) (*v1.ControllerRevisionList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ControllerRevision, err error)
 	ControllerRevisionExpansion
 }
 
 // controllerRevisions implements ControllerRevisionInterface
 type controllerRevisions struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newControllerRevisions returns a ControllerRevisions
@@ -64,9 +65,10 @@ func newControllerRevisions(c *AppsV1Client, namespace string) *controllerRevisi
 
 func newControllerRevisionsWithMultiTenancy(c *AppsV1Client, namespace string, tenant string) *controllerRevisions {
 	return &controllerRevisions{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *controllerRevisions) List(opts metav1.ListOptions) (result *v1.Controll
 }
 
 // Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *controllerRevisions) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *controllerRevisions) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("controllerrevisions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -47,7 +47,7 @@ type DeploymentInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.Deployment, error)
 	List(opts metav1.ListOptions) (*v1.DeploymentList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Deployment, err error)
 	GetScale(deploymentName string, options metav1.GetOptions) (*autoscalingv1.Scale, error)
 	UpdateScale(deploymentName string, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error)
@@ -57,9 +57,10 @@ type DeploymentInterface interface {
 
 // deployments implements DeploymentInterface
 type deployments struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newDeployments returns a Deployments
@@ -69,9 +70,10 @@ func newDeployments(c *AppsV1Client, namespace string) *deployments {
 
 func newDeploymentsWithMultiTenancy(c *AppsV1Client, namespace string, tenant string) *deployments {
 	return &deployments{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -109,19 +111,24 @@ func (c *deployments) List(opts metav1.ListOptions) (result *v1.DeploymentList, 
 }
 
 // Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *deployments) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("deployments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_controllerrevision.go
@@ -74,11 +74,14 @@ func (c *FakeControllerRevisions) List(opts v1.ListOptions) (result *appsv1.Cont
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested controllerRevisions.
+func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(controllerrevisionsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_daemonset.go
@@ -74,11 +74,14 @@ func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *appsv1.DaemonSetList
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested daemonSets.
+func (c *FakeDaemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(daemonsetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_deployment.go
@@ -75,11 +75,14 @@ func (c *FakeDeployments) List(opts v1.ListOptions) (result *appsv1.DeploymentLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested deployments.
+func (c *FakeDeployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(deploymentsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_replicaset.go
@@ -75,11 +75,14 @@ func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *appsv1.ReplicaSetLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested replicaSets.
+func (c *FakeReplicaSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(replicasetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_statefulset.go
@@ -75,11 +75,14 @@ func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *appsv1.StatefulSet
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested statefulSets.
+func (c *FakeStatefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(statefulsetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -45,16 +45,17 @@ type ControllerRevisionInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.ControllerRevision, error)
 	List(opts v1.ListOptions) (*v1beta1.ControllerRevisionList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ControllerRevision, err error)
 	ControllerRevisionExpansion
 }
 
 // controllerRevisions implements ControllerRevisionInterface
 type controllerRevisions struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newControllerRevisions returns a ControllerRevisions
@@ -64,9 +65,10 @@ func newControllerRevisions(c *AppsV1beta1Client, namespace string) *controllerR
 
 func newControllerRevisionsWithMultiTenancy(c *AppsV1beta1Client, namespace string, tenant string) *controllerRevisions {
 	return &controllerRevisions{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Control
 }
 
 // Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *controllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("controllerrevisions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -46,16 +46,17 @@ type DeploymentInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.Deployment, error)
 	List(opts v1.ListOptions) (*v1beta1.DeploymentList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Deployment, err error)
 	DeploymentExpansion
 }
 
 // deployments implements DeploymentInterface
 type deployments struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newDeployments returns a Deployments
@@ -65,9 +66,10 @@ func newDeployments(c *AppsV1beta1Client, namespace string) *deployments {
 
 func newDeploymentsWithMultiTenancy(c *AppsV1beta1Client, namespace string, tenant string) *deployments {
 	return &deployments{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 }
 
 // Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *deployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("deployments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
@@ -74,11 +74,14 @@ func (c *FakeControllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Con
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested controllerRevisions.
+func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(controllerrevisionsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
@@ -74,11 +74,14 @@ func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentL
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested deployments.
+func (c *FakeDeployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(deploymentsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
@@ -74,11 +74,14 @@ func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSe
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested statefulSets.
+func (c *FakeStatefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(statefulsetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -45,16 +45,17 @@ type ControllerRevisionInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta2.ControllerRevision, error)
 	List(opts v1.ListOptions) (*v1beta2.ControllerRevisionList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.ControllerRevision, err error)
 	ControllerRevisionExpansion
 }
 
 // controllerRevisions implements ControllerRevisionInterface
 type controllerRevisions struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newControllerRevisions returns a ControllerRevisions
@@ -64,9 +65,10 @@ func newControllerRevisions(c *AppsV1beta2Client, namespace string) *controllerR
 
 func newControllerRevisionsWithMultiTenancy(c *AppsV1beta2Client, namespace string, tenant string) *controllerRevisions {
 	return &controllerRevisions{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Control
 }
 
 // Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *controllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("controllerrevisions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -46,16 +46,17 @@ type DaemonSetInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta2.DaemonSet, error)
 	List(opts v1.ListOptions) (*v1beta2.DaemonSetList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.DaemonSet, err error)
 	DaemonSetExpansion
 }
 
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newDaemonSets returns a DaemonSets
@@ -65,9 +66,10 @@ func newDaemonSets(c *AppsV1beta2Client, namespace string) *daemonSets {
 
 func newDaemonSetsWithMultiTenancy(c *AppsV1beta2Client, namespace string, tenant string) *daemonSets {
 	return &daemonSets{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetList, e
 }
 
 // Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *daemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("daemonsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_controllerrevision.go
@@ -74,11 +74,14 @@ func (c *FakeControllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Con
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested controllerRevisions.
+func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(controllerrevisionsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_daemonset.go
@@ -74,11 +74,14 @@ func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetLis
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested daemonSets.
+func (c *FakeDaemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(daemonsetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
@@ -74,11 +74,14 @@ func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentL
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested deployments.
+func (c *FakeDeployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(deploymentsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_replicaset.go
@@ -74,11 +74,14 @@ func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *v1beta2.ReplicaSetL
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested replicaSets.
+func (c *FakeReplicaSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(replicasetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
@@ -74,11 +74,14 @@ func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSe
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested statefulSets.
+func (c *FakeStatefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(statefulsetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -46,7 +46,7 @@ type StatefulSetInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta2.StatefulSet, error)
 	List(opts v1.ListOptions) (*v1beta2.StatefulSetList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.StatefulSet, err error)
 	GetScale(statefulSetName string, options v1.GetOptions) (*v1beta2.Scale, error)
 	UpdateScale(statefulSetName string, scale *v1beta2.Scale) (*v1beta2.Scale, error)
@@ -56,9 +56,10 @@ type StatefulSetInterface interface {
 
 // statefulSets implements StatefulSetInterface
 type statefulSets struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newStatefulSets returns a StatefulSets
@@ -68,9 +69,10 @@ func newStatefulSets(c *AppsV1beta2Client, namespace string) *statefulSets {
 
 func newStatefulSetsWithMultiTenancy(c *AppsV1beta2Client, namespace string, tenant string) *statefulSets {
 	return &statefulSets{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -108,19 +110,24 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetLis
 }
 
 // Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *statefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("statefulsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/fake/fake_auditsink.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/fake/fake_auditsink.go
@@ -73,11 +73,14 @@ func (c *FakeAuditSinks) List(opts v1.ListOptions) (result *v1alpha1.AuditSinkLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested auditSinks.
-func (c *FakeAuditSinks) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested auditSinks.
+func (c *FakeAuditSinks) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(auditsinksResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a auditSink and creates it.  Returns the server's representation of the auditSink, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview.go
@@ -37,8 +37,9 @@ type TokenReviewInterface interface {
 
 // tokenReviews implements TokenReviewInterface
 type tokenReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newTokenReviews returns a TokenReviews
@@ -48,7 +49,8 @@ func newTokenReviews(c *AuthenticationV1Client) *tokenReviews {
 
 func newTokenReviewsWithMultiTenancy(c *AuthenticationV1Client, tenant string) *tokenReviews {
 	return &tokenReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
@@ -37,8 +37,9 @@ type TokenReviewInterface interface {
 
 // tokenReviews implements TokenReviewInterface
 type tokenReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newTokenReviews returns a TokenReviews
@@ -48,7 +49,8 @@ func newTokenReviews(c *AuthenticationV1beta1Client) *tokenReviews {
 
 func newTokenReviewsWithMultiTenancy(c *AuthenticationV1beta1Client, tenant string) *tokenReviews {
 	return &tokenReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
@@ -37,9 +37,10 @@ type LocalSubjectAccessReviewInterface interface {
 
 // localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
 type localSubjectAccessReviews struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newLocalSubjectAccessReviews returns a LocalSubjectAccessReviews
@@ -49,8 +50,9 @@ func newLocalSubjectAccessReviews(c *AuthorizationV1Client, namespace string) *l
 
 func newLocalSubjectAccessReviewsWithMultiTenancy(c *AuthorizationV1Client, namespace string, tenant string) *localSubjectAccessReviews {
 	return &localSubjectAccessReviews{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
@@ -37,8 +37,9 @@ type SelfSubjectAccessReviewInterface interface {
 
 // selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
 type selfSubjectAccessReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews
@@ -48,7 +49,8 @@ func newSelfSubjectAccessReviews(c *AuthorizationV1Client) *selfSubjectAccessRev
 
 func newSelfSubjectAccessReviewsWithMultiTenancy(c *AuthorizationV1Client, tenant string) *selfSubjectAccessReviews {
 	return &selfSubjectAccessReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
@@ -37,8 +37,9 @@ type SelfSubjectRulesReviewInterface interface {
 
 // selfSubjectRulesReviews implements SelfSubjectRulesReviewInterface
 type selfSubjectRulesReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newSelfSubjectRulesReviews returns a SelfSubjectRulesReviews
@@ -48,7 +49,8 @@ func newSelfSubjectRulesReviews(c *AuthorizationV1Client) *selfSubjectRulesRevie
 
 func newSelfSubjectRulesReviewsWithMultiTenancy(c *AuthorizationV1Client, tenant string) *selfSubjectRulesReviews {
 	return &selfSubjectRulesReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
@@ -37,8 +37,9 @@ type SubjectAccessReviewInterface interface {
 
 // subjectAccessReviews implements SubjectAccessReviewInterface
 type subjectAccessReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newSubjectAccessReviews returns a SubjectAccessReviews
@@ -48,7 +49,8 @@ func newSubjectAccessReviews(c *AuthorizationV1Client) *subjectAccessReviews {
 
 func newSubjectAccessReviewsWithMultiTenancy(c *AuthorizationV1Client, tenant string) *subjectAccessReviews {
 	return &subjectAccessReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
@@ -37,9 +37,10 @@ type LocalSubjectAccessReviewInterface interface {
 
 // localSubjectAccessReviews implements LocalSubjectAccessReviewInterface
 type localSubjectAccessReviews struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newLocalSubjectAccessReviews returns a LocalSubjectAccessReviews
@@ -49,8 +50,9 @@ func newLocalSubjectAccessReviews(c *AuthorizationV1beta1Client, namespace strin
 
 func newLocalSubjectAccessReviewsWithMultiTenancy(c *AuthorizationV1beta1Client, namespace string, tenant string) *localSubjectAccessReviews {
 	return &localSubjectAccessReviews{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
@@ -37,8 +37,9 @@ type SelfSubjectAccessReviewInterface interface {
 
 // selfSubjectAccessReviews implements SelfSubjectAccessReviewInterface
 type selfSubjectAccessReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newSelfSubjectAccessReviews returns a SelfSubjectAccessReviews
@@ -48,7 +49,8 @@ func newSelfSubjectAccessReviews(c *AuthorizationV1beta1Client) *selfSubjectAcce
 
 func newSelfSubjectAccessReviewsWithMultiTenancy(c *AuthorizationV1beta1Client, tenant string) *selfSubjectAccessReviews {
 	return &selfSubjectAccessReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
@@ -37,8 +37,9 @@ type SelfSubjectRulesReviewInterface interface {
 
 // selfSubjectRulesReviews implements SelfSubjectRulesReviewInterface
 type selfSubjectRulesReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newSelfSubjectRulesReviews returns a SelfSubjectRulesReviews
@@ -48,7 +49,8 @@ func newSelfSubjectRulesReviews(c *AuthorizationV1beta1Client) *selfSubjectRules
 
 func newSelfSubjectRulesReviewsWithMultiTenancy(c *AuthorizationV1beta1Client, tenant string) *selfSubjectRulesReviews {
 	return &selfSubjectRulesReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
@@ -37,8 +37,9 @@ type SubjectAccessReviewInterface interface {
 
 // subjectAccessReviews implements SubjectAccessReviewInterface
 type subjectAccessReviews struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newSubjectAccessReviews returns a SubjectAccessReviews
@@ -48,7 +49,8 @@ func newSubjectAccessReviews(c *AuthorizationV1beta1Client) *subjectAccessReview
 
 func newSubjectAccessReviewsWithMultiTenancy(c *AuthorizationV1beta1Client, tenant string) *subjectAccessReviews {
 	return &subjectAccessReviews{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -74,11 +74,14 @@ func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *autosc
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested horizontalPodAutoscalers.
+func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(horizontalpodautoscalersResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -46,16 +46,17 @@ type HorizontalPodAutoscalerInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.HorizontalPodAutoscaler, error)
 	List(opts metav1.ListOptions) (*v1.HorizontalPodAutoscalerList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newHorizontalPodAutoscalers returns a HorizontalPodAutoscalers
@@ -65,9 +66,10 @@ func newHorizontalPodAutoscalers(c *AutoscalingV1Client, namespace string) *hori
 
 func newHorizontalPodAutoscalersWithMultiTenancy(c *AutoscalingV1Client, namespace string, tenant string) *horizontalPodAutoscalers {
 	return &horizontalPodAutoscalers{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *horizontalPodAutoscalers) List(opts metav1.ListOptions) (result *v1.Hor
 }
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *horizontalPodAutoscalers) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("horizontalpodautoscalers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_horizontalpodautoscaler.go
@@ -74,11 +74,14 @@ func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested horizontalPodAutoscalers.
+func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(horizontalpodautoscalersResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -46,16 +46,17 @@ type HorizontalPodAutoscalerInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v2beta1.HorizontalPodAutoscaler, error)
 	List(opts v1.ListOptions) (*v2beta1.HorizontalPodAutoscalerList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v2beta1.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newHorizontalPodAutoscalers returns a HorizontalPodAutoscalers
@@ -65,9 +66,10 @@ func newHorizontalPodAutoscalers(c *AutoscalingV2beta1Client, namespace string) 
 
 func newHorizontalPodAutoscalersWithMultiTenancy(c *AutoscalingV2beta1Client, namespace string, tenant string) *horizontalPodAutoscalers {
 	return &horizontalPodAutoscalers{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta1.Ho
 }
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("horizontalpodautoscalers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_horizontalpodautoscaler.go
@@ -74,11 +74,14 @@ func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested horizontalPodAutoscalers.
+func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(horizontalpodautoscalersResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -46,16 +46,17 @@ type HorizontalPodAutoscalerInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v2beta2.HorizontalPodAutoscaler, error)
 	List(opts v1.ListOptions) (*v2beta2.HorizontalPodAutoscalerList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v2beta2.HorizontalPodAutoscaler, err error)
 	HorizontalPodAutoscalerExpansion
 }
 
 // horizontalPodAutoscalers implements HorizontalPodAutoscalerInterface
 type horizontalPodAutoscalers struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newHorizontalPodAutoscalers returns a HorizontalPodAutoscalers
@@ -65,9 +66,10 @@ func newHorizontalPodAutoscalers(c *AutoscalingV2beta2Client, namespace string) 
 
 func newHorizontalPodAutoscalersWithMultiTenancy(c *AutoscalingV2beta2Client, namespace string, tenant string) *horizontalPodAutoscalers {
 	return &horizontalPodAutoscalers{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta2.Ho
 }
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("horizontalpodautoscalers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
@@ -74,11 +74,14 @@ func (c *FakeJobs) List(opts v1.ListOptions) (result *batchv1.JobList, err error
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested jobs.
-func (c *FakeJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested jobs.
+func (c *FakeJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(jobsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -46,16 +46,17 @@ type CronJobInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.CronJob, error)
 	List(opts v1.ListOptions) (*v1beta1.CronJobList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.CronJob, err error)
 	CronJobExpansion
 }
 
 // cronJobs implements CronJobInterface
 type cronJobs struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newCronJobs returns a CronJobs
@@ -65,9 +66,10 @@ func newCronJobs(c *BatchV1beta1Client, namespace string) *cronJobs {
 
 func newCronJobsWithMultiTenancy(c *BatchV1beta1Client, namespace string, tenant string) *cronJobs {
 	return &cronJobs{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, err e
 }
 
 // Watch returns a watch.Interface that watches the requested cronJobs.
-func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *cronJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("cronjobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("cronjobs").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_cronjob.go
@@ -74,11 +74,14 @@ func (c *FakeCronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, e
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested cronJobs.
-func (c *FakeCronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested cronJobs.
+func (c *FakeCronJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(cronjobsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
@@ -74,11 +74,14 @@ func (c *FakeCronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested cronJobs.
-func (c *FakeCronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested cronJobs.
+func (c *FakeCronJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(cronjobsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
@@ -73,11 +73,14 @@ func (c *FakeCertificateSigningRequests) List(opts v1.ListOptions) (result *v1be
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested certificateSigningRequests.
-func (c *FakeCertificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested certificateSigningRequests.
+func (c *FakeCertificateSigningRequests) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(certificatesigningrequestsResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a certificateSigningRequest and creates it.  Returns the server's representation of the certificateSigningRequest, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_lease.go
@@ -74,11 +74,14 @@ func (c *FakeLeases) List(opts v1.ListOptions) (result *coordinationv1.LeaseList
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested leases.
-func (c *FakeLeases) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested leases.
+func (c *FakeLeases) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(leasesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a lease and creates it.  Returns the server's representation of the lease, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_lease.go
@@ -74,11 +74,14 @@ func (c *FakeLeases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err e
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested leases.
-func (c *FakeLeases) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested leases.
+func (c *FakeLeases) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(leasesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a lease and creates it.  Returns the server's representation of the lease, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -45,16 +45,17 @@ type LeaseInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.Lease, error)
 	List(opts v1.ListOptions) (*v1beta1.LeaseList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Lease, err error)
 	LeaseExpansion
 }
 
 // leases implements LeaseInterface
 type leases struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newLeases returns a Leases
@@ -64,9 +65,10 @@ func newLeases(c *CoordinationV1beta1Client, namespace string) *leases {
 
 func newLeasesWithMultiTenancy(c *CoordinationV1beta1Client, namespace string, tenant string) *leases {
 	return &leases{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *leases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err error
 }
 
 // Watch returns a watch.Interface that watches the requested leases.
-func (c *leases) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *leases) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("leases").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("leases").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a lease and creates it.  Returns the server's representation of the lease, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
@@ -45,16 +45,17 @@ type ActionInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.Action, error)
 	List(opts metav1.ListOptions) (*v1.ActionList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Action, err error)
 	ActionExpansion
 }
 
 // actions implements ActionInterface
 type actions struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newActions returns a Actions
@@ -64,9 +65,10 @@ func newActions(c *CoreV1Client, namespace string) *actions {
 
 func newActionsWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *actions {
 	return &actions{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *actions) List(opts metav1.ListOptions) (result *v1.ActionList, err erro
 }
 
 // Watch returns a watch.Interface that watches the requested actions.
-func (c *actions) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *actions) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("actions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("actions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a action and creates it.  Returns the server's representation of the action, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -45,16 +45,17 @@ type ConfigMapInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.ConfigMap, error)
 	List(opts metav1.ListOptions) (*v1.ConfigMapList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error)
 	ConfigMapExpansion
 }
 
 // configMaps implements ConfigMapInterface
 type configMaps struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newConfigMaps returns a ConfigMaps
@@ -64,9 +65,10 @@ func newConfigMaps(c *CoreV1Client, namespace string) *configMaps {
 
 func newConfigMapsWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *configMaps {
 	return &configMaps{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *configMaps) List(opts metav1.ListOptions) (result *v1.ConfigMapList, er
 }
 
 // Watch returns a watch.Interface that watches the requested configMaps.
-func (c *configMaps) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *configMaps) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("configmaps").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -45,16 +45,17 @@ type EndpointsInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.Endpoints, error)
 	List(opts metav1.ListOptions) (*v1.EndpointsList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Endpoints, err error)
 	EndpointsExpansion
 }
 
 // endpoints implements EndpointsInterface
 type endpoints struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newEndpoints returns a Endpoints
@@ -64,9 +65,10 @@ func newEndpoints(c *CoreV1Client, namespace string) *endpoints {
 
 func newEndpointsWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *endpoints {
 	return &endpoints{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *endpoints) List(opts metav1.ListOptions) (result *v1.EndpointsList, err
 }
 
 // Watch returns a watch.Interface that watches the requested endpoints.
-func (c *endpoints) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *endpoints) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("endpoints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("endpoints").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_action.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_action.go
@@ -73,11 +73,14 @@ func (c *FakeActions) List(opts v1.ListOptions) (result *corev1.ActionList, err 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested actions.
-func (c *FakeActions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested actions.
+func (c *FakeActions) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(actionsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a action and creates it.  Returns the server's representation of the action, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
@@ -70,10 +70,13 @@ func (c *FakeComponentStatuses) List(opts v1.ListOptions) (result *corev1.Compon
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested componentStatuses.
-func (c *FakeComponentStatuses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested componentStatuses.
+func (c *FakeComponentStatuses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(componentstatusesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
@@ -74,11 +74,14 @@ func (c *FakeConfigMaps) List(opts v1.ListOptions) (result *corev1.ConfigMapList
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested configMaps.
-func (c *FakeConfigMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested configMaps.
+func (c *FakeConfigMaps) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(configmapsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_controllerinstance.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_controllerinstance.go
@@ -69,10 +69,13 @@ func (c *FakeControllerInstances) List(opts v1.ListOptions) (result *corev1.Cont
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested controllerInstances.
-func (c *FakeControllerInstances) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested controllerInstances.
+func (c *FakeControllerInstances) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(controllerinstancesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a controllerInstance and creates it.  Returns the server's representation of the controllerInstance, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
@@ -74,11 +74,14 @@ func (c *FakeEndpoints) List(opts v1.ListOptions) (result *corev1.EndpointsList,
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested endpoints.
-func (c *FakeEndpoints) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested endpoints.
+func (c *FakeEndpoints) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(endpointsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
@@ -74,11 +74,14 @@ func (c *FakeEvents) List(opts v1.ListOptions) (result *corev1.EventList, err er
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested events.
-func (c *FakeEvents) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested events.
+func (c *FakeEvents) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(eventsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
@@ -74,11 +74,14 @@ func (c *FakeLimitRanges) List(opts v1.ListOptions) (result *corev1.LimitRangeLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested limitRanges.
-func (c *FakeLimitRanges) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested limitRanges.
+func (c *FakeLimitRanges) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(limitrangesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
@@ -73,11 +73,14 @@ func (c *FakeNamespaces) List(opts v1.ListOptions) (result *corev1.NamespaceList
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested namespaces.
-func (c *FakeNamespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested namespaces.
+func (c *FakeNamespaces) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(namespacesResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
@@ -70,10 +70,13 @@ func (c *FakeNodes) List(opts v1.ListOptions) (result *corev1.NodeList, err erro
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested nodes.
-func (c *FakeNodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested nodes.
+func (c *FakeNodes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(nodesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
@@ -73,11 +73,14 @@ func (c *FakePersistentVolumes) List(opts v1.ListOptions) (result *corev1.Persis
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested persistentVolumes.
-func (c *FakePersistentVolumes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested persistentVolumes.
+func (c *FakePersistentVolumes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(persistentvolumesResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
@@ -74,11 +74,14 @@ func (c *FakePersistentVolumeClaims) List(opts v1.ListOptions) (result *corev1.P
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
-func (c *FakePersistentVolumeClaims) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested persistentVolumeClaims.
+func (c *FakePersistentVolumeClaims) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(persistentvolumeclaimsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -74,11 +74,14 @@ func (c *FakePods) List(opts v1.ListOptions) (result *corev1.PodList, err error)
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested pods.
-func (c *FakePods) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested pods.
+func (c *FakePods) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(podsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
@@ -74,11 +74,14 @@ func (c *FakePodTemplates) List(opts v1.ListOptions) (result *corev1.PodTemplate
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested podTemplates.
-func (c *FakePodTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested podTemplates.
+func (c *FakePodTemplates) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(podtemplatesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
@@ -75,11 +75,14 @@ func (c *FakeReplicationControllers) List(opts v1.ListOptions) (result *corev1.R
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested replicationControllers.
-func (c *FakeReplicationControllers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested replicationControllers.
+func (c *FakeReplicationControllers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(replicationcontrollersResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
@@ -74,11 +74,14 @@ func (c *FakeResourceQuotas) List(opts v1.ListOptions) (result *corev1.ResourceQ
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested resourceQuotas.
-func (c *FakeResourceQuotas) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested resourceQuotas.
+func (c *FakeResourceQuotas) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(resourcequotasResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
@@ -74,11 +74,14 @@ func (c *FakeSecrets) List(opts v1.ListOptions) (result *corev1.SecretList, err 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested secrets.
-func (c *FakeSecrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested secrets.
+func (c *FakeSecrets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(secretsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
@@ -74,11 +74,14 @@ func (c *FakeServices) List(opts v1.ListOptions) (result *corev1.ServiceList, er
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested services.
-func (c *FakeServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested services.
+func (c *FakeServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(servicesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
@@ -74,11 +74,14 @@ func (c *FakeServiceAccounts) List(opts v1.ListOptions) (result *corev1.ServiceA
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested serviceAccounts.
-func (c *FakeServiceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested serviceAccounts.
+func (c *FakeServiceAccounts) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(serviceaccountsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_tenant.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_tenant.go
@@ -69,10 +69,13 @@ func (c *FakeTenants) List(opts v1.ListOptions) (result *corev1.TenantList, err 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested tenants.
-func (c *FakeTenants) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested tenants.
+func (c *FakeTenants) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(tenantsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a tenant and creates it.  Returns the server's representation of the tenant, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -45,16 +45,17 @@ type LimitRangeInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.LimitRange, error)
 	List(opts metav1.ListOptions) (*v1.LimitRangeList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.LimitRange, err error)
 	LimitRangeExpansion
 }
 
 // limitRanges implements LimitRangeInterface
 type limitRanges struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newLimitRanges returns a LimitRanges
@@ -64,9 +65,10 @@ func newLimitRanges(c *CoreV1Client, namespace string) *limitRanges {
 
 func newLimitRangesWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *limitRanges {
 	return &limitRanges{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *limitRanges) List(opts metav1.ListOptions) (result *v1.LimitRangeList, 
 }
 
 // Watch returns a watch.Interface that watches the requested limitRanges.
-func (c *limitRanges) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *limitRanges) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("limitranges").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("limitranges").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -45,20 +45,22 @@ type NodeInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.Node, error)
 	List(opts metav1.ListOptions) (*v1.NodeList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Node, err error)
 	NodeExpansion
 }
 
 // nodes implements NodeInterface
 type nodes struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newNodes returns a Nodes
 func newNodes(c *CoreV1Client) *nodes {
 	return &nodes{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -93,17 +95,22 @@ func (c *nodes) List(opts metav1.ListOptions) (result *v1.NodeList, err error) {
 }
 
 // Watch returns a watch.Interface that watches the requested nodes.
-func (c *nodes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *nodes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("nodes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -46,16 +46,17 @@ type PersistentVolumeClaimInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.PersistentVolumeClaim, error)
 	List(opts metav1.ListOptions) (*v1.PersistentVolumeClaimList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolumeClaim, err error)
 	PersistentVolumeClaimExpansion
 }
 
 // persistentVolumeClaims implements PersistentVolumeClaimInterface
 type persistentVolumeClaims struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newPersistentVolumeClaims returns a PersistentVolumeClaims
@@ -65,9 +66,10 @@ func newPersistentVolumeClaims(c *CoreV1Client, namespace string) *persistentVol
 
 func newPersistentVolumeClaimsWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *persistentVolumeClaims {
 	return &persistentVolumeClaims{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *persistentVolumeClaims) List(opts metav1.ListOptions) (result *v1.Persi
 }
 
 // Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
-func (c *persistentVolumeClaims) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *persistentVolumeClaims) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("persistentvolumeclaims").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -45,16 +45,17 @@ type PodTemplateInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.PodTemplate, error)
 	List(opts metav1.ListOptions) (*v1.PodTemplateList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.PodTemplate, err error)
 	PodTemplateExpansion
 }
 
 // podTemplates implements PodTemplateInterface
 type podTemplates struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newPodTemplates returns a PodTemplates
@@ -64,9 +65,10 @@ func newPodTemplates(c *CoreV1Client, namespace string) *podTemplates {
 
 func newPodTemplatesWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *podTemplates {
 	return &podTemplates{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *podTemplates) List(opts metav1.ListOptions) (result *v1.PodTemplateList
 }
 
 // Watch returns a watch.Interface that watches the requested podTemplates.
-func (c *podTemplates) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *podTemplates) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("podtemplates").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("podtemplates").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -47,7 +47,7 @@ type ReplicationControllerInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.ReplicationController, error)
 	List(opts metav1.ListOptions) (*v1.ReplicationControllerList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ReplicationController, err error)
 	GetScale(replicationControllerName string, options metav1.GetOptions) (*autoscalingv1.Scale, error)
 	UpdateScale(replicationControllerName string, scale *autoscalingv1.Scale) (*autoscalingv1.Scale, error)
@@ -57,9 +57,10 @@ type ReplicationControllerInterface interface {
 
 // replicationControllers implements ReplicationControllerInterface
 type replicationControllers struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newReplicationControllers returns a ReplicationControllers
@@ -69,9 +70,10 @@ func newReplicationControllers(c *CoreV1Client, namespace string) *replicationCo
 
 func newReplicationControllersWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *replicationControllers {
 	return &replicationControllers{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -109,19 +111,24 @@ func (c *replicationControllers) List(opts metav1.ListOptions) (result *v1.Repli
 }
 
 // Watch returns a watch.Interface that watches the requested replicationControllers.
-func (c *replicationControllers) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *replicationControllers) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("replicationcontrollers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("replicationcontrollers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -45,16 +45,17 @@ type ServiceAccountInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.ServiceAccount, error)
 	List(opts metav1.ListOptions) (*v1.ServiceAccountList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ServiceAccount, err error)
 	ServiceAccountExpansion
 }
 
 // serviceAccounts implements ServiceAccountInterface
 type serviceAccounts struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newServiceAccounts returns a ServiceAccounts
@@ -64,9 +65,10 @@ func newServiceAccounts(c *CoreV1Client, namespace string) *serviceAccounts {
 
 func newServiceAccountsWithMultiTenancy(c *CoreV1Client, namespace string, tenant string) *serviceAccounts {
 	return &serviceAccounts{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *serviceAccounts) List(opts metav1.ListOptions) (result *v1.ServiceAccou
 }
 
 // Watch returns a watch.Interface that watches the requested serviceAccounts.
-func (c *serviceAccounts) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *serviceAccounts) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("serviceaccounts").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("serviceaccounts").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
@@ -43,20 +43,22 @@ type TenantInterface interface {
 	Delete(name string, options *metav1.DeleteOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.Tenant, error)
 	List(opts metav1.ListOptions) (*v1.TenantList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Tenant, err error)
 	TenantExpansion
 }
 
 // tenants implements TenantInterface
 type tenants struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newTenants returns a Tenants
 func newTenants(c *CoreV1Client) *tenants {
 	return &tenants{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -91,17 +93,22 @@ func (c *tenants) List(opts metav1.ListOptions) (result *v1.TenantList, err erro
 }
 
 // Watch returns a watch.Interface that watches the requested tenants.
-func (c *tenants) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *tenants) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("tenants").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("tenants").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a tenant and creates it.  Returns the server's representation of the tenant, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -45,16 +45,17 @@ type EventInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.Event, error)
 	List(opts v1.ListOptions) (*v1beta1.EventList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Event, err error)
 	EventExpansion
 }
 
 // events implements EventInterface
 type events struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newEvents returns a Events
@@ -64,9 +65,10 @@ func newEvents(c *EventsV1beta1Client, namespace string) *events {
 
 func newEventsWithMultiTenancy(c *EventsV1beta1Client, namespace string, tenant string) *events {
 	return &events{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *events) List(opts v1.ListOptions) (result *v1beta1.EventList, err error
 }
 
 // Watch returns a watch.Interface that watches the requested events.
-func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *events) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("events").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
@@ -74,11 +74,14 @@ func (c *FakeEvents) List(opts v1.ListOptions) (result *v1beta1.EventList, err e
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested events.
-func (c *FakeEvents) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested events.
+func (c *FakeEvents) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(eventsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -46,16 +46,17 @@ type DaemonSetInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.DaemonSet, error)
 	List(opts v1.ListOptions) (*v1beta1.DaemonSetList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.DaemonSet, err error)
 	DaemonSetExpansion
 }
 
 // daemonSets implements DaemonSetInterface
 type daemonSets struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newDaemonSets returns a DaemonSets
@@ -65,9 +66,10 @@ func newDaemonSets(c *ExtensionsV1beta1Client, namespace string) *daemonSets {
 
 func newDaemonSetsWithMultiTenancy(c *ExtensionsV1beta1Client, namespace string, tenant string) *daemonSets {
 	return &daemonSets{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 }
 
 // Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *daemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("daemonsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -74,11 +74,14 @@ func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetLis
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested daemonSets.
+func (c *FakeDaemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(daemonsetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -74,11 +74,14 @@ func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentL
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested deployments.
+func (c *FakeDeployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(deploymentsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -74,11 +74,14 @@ func (c *FakeIngresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested ingresses.
+func (c *FakeIngresses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(ingressesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_networkpolicy.go
@@ -74,11 +74,14 @@ func (c *FakeNetworkPolicies) List(opts v1.ListOptions) (result *v1beta1.Network
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested networkPolicies.
-func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested networkPolicies.
+func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(networkpoliciesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
@@ -73,11 +73,14 @@ func (c *FakePodSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.Pod
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested podSecurityPolicies.
-func (c *FakePodSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested podSecurityPolicies.
+func (c *FakePodSecurityPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(podsecuritypoliciesResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -74,11 +74,14 @@ func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetL
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested replicaSets.
+func (c *FakeReplicaSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(replicasetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -46,16 +46,17 @@ type IngressInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.Ingress, error)
 	List(opts v1.ListOptions) (*v1beta1.IngressList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Ingress, err error)
 	IngressExpansion
 }
 
 // ingresses implements IngressInterface
 type ingresses struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newIngresses returns a Ingresses
@@ -65,9 +66,10 @@ func newIngresses(c *ExtensionsV1beta1Client, namespace string) *ingresses {
 
 func newIngressesWithMultiTenancy(c *ExtensionsV1beta1Client, namespace string, tenant string) *ingresses {
 	return &ingresses{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 }
 
 // Watch returns a watch.Interface that watches the requested ingresses.
-func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ingresses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("ingresses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -45,16 +45,17 @@ type NetworkPolicyInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.NetworkPolicy, error)
 	List(opts v1.ListOptions) (*v1beta1.NetworkPolicyList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.NetworkPolicy, err error)
 	NetworkPolicyExpansion
 }
 
 // networkPolicies implements NetworkPolicyInterface
 type networkPolicies struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newNetworkPolicies returns a NetworkPolicies
@@ -64,9 +65,10 @@ func newNetworkPolicies(c *ExtensionsV1beta1Client, namespace string) *networkPo
 
 func newNetworkPoliciesWithMultiTenancy(c *ExtensionsV1beta1Client, namespace string, tenant string) *networkPolicies {
 	return &networkPolicies{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *v1beta1.NetworkPoli
 }
 
 // Watch returns a watch.Interface that watches the requested networkPolicies.
-func (c *networkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *networkPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("networkpolicies").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
@@ -74,11 +74,14 @@ func (c *FakeNetworkPolicies) List(opts v1.ListOptions) (result *networkingv1.Ne
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested networkPolicies.
-func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested networkPolicies.
+func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(networkpoliciesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingress.go
@@ -74,11 +74,14 @@ func (c *FakeIngresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested ingresses.
+func (c *FakeIngresses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(ingressesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_runtimeclass.go
@@ -70,10 +70,13 @@ func (c *FakeRuntimeClasses) List(opts v1.ListOptions) (result *v1alpha1.Runtime
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested runtimeClasses.
-func (c *FakeRuntimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested runtimeClasses.
+func (c *FakeRuntimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(runtimeclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -44,20 +44,22 @@ type RuntimeClassInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.RuntimeClass, error)
 	List(opts v1.ListOptions) (*v1alpha1.RuntimeClassList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.RuntimeClass, err error)
 	RuntimeClassExpansion
 }
 
 // runtimeClasses implements RuntimeClassInterface
 type runtimeClasses struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newRuntimeClasses returns a RuntimeClasses
 func newRuntimeClasses(c *NodeV1alpha1Client) *runtimeClasses {
 	return &runtimeClasses{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 }
 
 // Watch returns a watch.Interface that watches the requested runtimeClasses.
-func (c *runtimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("runtimeclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("runtimeclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_runtimeclass.go
@@ -70,10 +70,13 @@ func (c *FakeRuntimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeC
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested runtimeClasses.
-func (c *FakeRuntimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested runtimeClasses.
+func (c *FakeRuntimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(runtimeclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -44,20 +44,22 @@ type RuntimeClassInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.RuntimeClass, error)
 	List(opts v1.ListOptions) (*v1beta1.RuntimeClassList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.RuntimeClass, err error)
 	RuntimeClassExpansion
 }
 
 // runtimeClasses implements RuntimeClassInterface
 type runtimeClasses struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newRuntimeClasses returns a RuntimeClasses
 func newRuntimeClasses(c *NodeV1beta1Client) *runtimeClasses {
 	return &runtimeClasses{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeClass
 }
 
 // Watch returns a watch.Interface that watches the requested runtimeClasses.
-func (c *runtimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("runtimeclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("runtimeclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction.go
@@ -37,9 +37,10 @@ type EvictionInterface interface {
 
 // evictions implements EvictionInterface
 type evictions struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newEvictions returns a Evictions
@@ -49,8 +50,9 @@ func newEvictions(c *PolicyV1beta1Client, namespace string) *evictions {
 
 func newEvictionsWithMultiTenancy(c *PolicyV1beta1Client, namespace string, tenant string) *evictions {
 	return &evictions{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
@@ -74,11 +74,14 @@ func (c *FakePodDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.Po
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
-func (c *FakePodDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested podDisruptionBudgets.
+func (c *FakePodDisruptionBudgets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(poddisruptionbudgetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_podsecuritypolicy.go
@@ -73,11 +73,14 @@ func (c *FakePodSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.Pod
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested podSecurityPolicies.
-func (c *FakePodSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested podSecurityPolicies.
+func (c *FakePodSecurityPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(podsecuritypoliciesResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -46,16 +46,17 @@ type PodDisruptionBudgetInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.PodDisruptionBudget, error)
 	List(opts v1.ListOptions) (*v1beta1.PodDisruptionBudgetList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.PodDisruptionBudget, err error)
 	PodDisruptionBudgetExpansion
 }
 
 // podDisruptionBudgets implements PodDisruptionBudgetInterface
 type podDisruptionBudgets struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newPodDisruptionBudgets returns a PodDisruptionBudgets
@@ -65,9 +66,10 @@ func newPodDisruptionBudgets(c *PolicyV1beta1Client, namespace string) *podDisru
 
 func newPodDisruptionBudgetsWithMultiTenancy(c *PolicyV1beta1Client, namespace string, tenant string) *podDisruptionBudgets {
 	return &podDisruptionBudgets{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 }
 
 // Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
-func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("poddisruptionbudgets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -45,15 +45,16 @@ type PodSecurityPolicyInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.PodSecurityPolicy, error)
 	List(opts v1.ListOptions) (*v1beta1.PodSecurityPolicyList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.PodSecurityPolicy, err error)
 	PodSecurityPolicyExpansion
 }
 
 // podSecurityPolicies implements PodSecurityPolicyInterface
 type podSecurityPolicies struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newPodSecurityPolicies returns a PodSecurityPolicies
@@ -63,8 +64,9 @@ func newPodSecurityPolicies(c *PolicyV1beta1Client) *podSecurityPolicies {
 
 func newPodSecurityPoliciesWithMultiTenancy(c *PolicyV1beta1Client, tenant string) *podSecurityPolicies {
 	return &podSecurityPolicies{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }
 
@@ -101,18 +103,23 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 }
 
 // Watch returns a watch.Interface that watches the requested podSecurityPolicies.
-func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *podSecurityPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Resource("podsecuritypolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Resource("podsecuritypolicies").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -44,20 +44,22 @@ type ClusterRoleInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.ClusterRole, error)
 	List(opts metav1.ListOptions) (*v1.ClusterRoleList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ClusterRole, err error)
 	ClusterRoleExpansion
 }
 
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newClusterRoles returns a ClusterRoles
 func newClusterRoles(c *RbacV1Client) *clusterRoles {
 	return &clusterRoles{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *clusterRoles) List(opts metav1.ListOptions) (result *v1.ClusterRoleList
 }
 
 // Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *clusterRoles) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *clusterRoles) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("clusterroles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -44,20 +44,22 @@ type ClusterRoleBindingInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.ClusterRoleBinding, error)
 	List(opts metav1.ListOptions) (*v1.ClusterRoleBindingList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ClusterRoleBinding, err error)
 	ClusterRoleBindingExpansion
 }
 
 // clusterRoleBindings implements ClusterRoleBindingInterface
 type clusterRoleBindings struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newClusterRoleBindings returns a ClusterRoleBindings
 func newClusterRoleBindings(c *RbacV1Client) *clusterRoleBindings {
 	return &clusterRoleBindings{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *clusterRoleBindings) List(opts metav1.ListOptions) (result *v1.ClusterR
 }
 
 // Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *clusterRoleBindings) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *clusterRoleBindings) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("clusterrolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrole.go
@@ -70,10 +70,13 @@ func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *rbacv1.ClusterRole
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterRoles.
+func (c *FakeClusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrolebinding.go
@@ -70,10 +70,13 @@ func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *rbacv1.Clus
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterRoleBindings.
+func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_role.go
@@ -74,11 +74,14 @@ func (c *FakeRoles) List(opts v1.ListOptions) (result *rbacv1.RoleList, err erro
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested roles.
-func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested roles.
+func (c *FakeRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(rolesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rolebinding.go
@@ -74,11 +74,14 @@ func (c *FakeRoleBindings) List(opts v1.ListOptions) (result *rbacv1.RoleBinding
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested roleBindings.
+func (c *FakeRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(rolebindingsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -45,16 +45,17 @@ type RoleInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.Role, error)
 	List(opts metav1.ListOptions) (*v1.RoleList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Role, err error)
 	RoleExpansion
 }
 
 // roles implements RoleInterface
 type roles struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newRoles returns a Roles
@@ -64,9 +65,10 @@ func newRoles(c *RbacV1Client, namespace string) *roles {
 
 func newRolesWithMultiTenancy(c *RbacV1Client, namespace string, tenant string) *roles {
 	return &roles{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *roles) List(opts metav1.ListOptions) (result *v1.RoleList, err error) {
 }
 
 // Watch returns a watch.Interface that watches the requested roles.
-func (c *roles) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *roles) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("roles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -44,20 +44,22 @@ type ClusterRoleInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.ClusterRole, error)
 	List(opts v1.ListOptions) (*v1alpha1.ClusterRoleList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.ClusterRole, err error)
 	ClusterRoleExpansion
 }
 
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newClusterRoles returns a ClusterRoles
 func newClusterRoles(c *RbacV1alpha1Client) *clusterRoles {
 	return &clusterRoles{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 }
 
 // Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *clusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("clusterroles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
@@ -70,10 +70,13 @@ func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRo
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterRoles.
+func (c *FakeClusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
@@ -70,10 +70,13 @@ func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cl
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterRoleBindings.
+func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
@@ -74,11 +74,14 @@ func (c *FakeRoles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err er
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested roles.
-func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested roles.
+func (c *FakeRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(rolesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
@@ -74,11 +74,14 @@ func (c *FakeRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested roleBindings.
+func (c *FakeRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(rolebindingsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -45,16 +45,17 @@ type RoleBindingInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.RoleBinding, error)
 	List(opts v1.ListOptions) (*v1alpha1.RoleBindingList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.RoleBinding, err error)
 	RoleBindingExpansion
 }
 
 // roleBindings implements RoleBindingInterface
 type roleBindings struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newRoleBindings returns a RoleBindings
@@ -64,9 +65,10 @@ func newRoleBindings(c *RbacV1alpha1Client, namespace string) *roleBindings {
 
 func newRoleBindingsWithMultiTenancy(c *RbacV1alpha1Client, namespace string, tenant string) *roleBindings {
 	return &roleBindings{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 }
 
 // Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *roleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("rolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -44,20 +44,22 @@ type ClusterRoleInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.ClusterRole, error)
 	List(opts v1.ListOptions) (*v1beta1.ClusterRoleList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterRole, err error)
 	ClusterRoleExpansion
 }
 
 // clusterRoles implements ClusterRoleInterface
 type clusterRoles struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newClusterRoles returns a ClusterRoles
 func newClusterRoles(c *RbacV1beta1Client) *clusterRoles {
 	return &clusterRoles{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 }
 
 // Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *clusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("clusterroles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -44,20 +44,22 @@ type ClusterRoleBindingInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.ClusterRoleBinding, error)
 	List(opts v1.ListOptions) (*v1beta1.ClusterRoleBindingList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterRoleBinding, err error)
 	ClusterRoleBindingExpansion
 }
 
 // clusterRoleBindings implements ClusterRoleBindingInterface
 type clusterRoleBindings struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newClusterRoleBindings returns a ClusterRoleBindings
 func newClusterRoleBindings(c *RbacV1beta1Client) *clusterRoleBindings {
 	return &clusterRoleBindings{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.Cluster
 }
 
 // Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *clusterRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("clusterrolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
@@ -70,10 +70,13 @@ func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRol
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterRoles.
+func (c *FakeClusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
@@ -70,10 +70,13 @@ func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.Clu
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterRoleBindings.
+func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
@@ -74,11 +74,14 @@ func (c *FakeRoles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err err
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested roles.
-func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested roles.
+func (c *FakeRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(rolesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
@@ -74,11 +74,14 @@ func (c *FakeRoleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindin
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested roleBindings.
+func (c *FakeRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(rolebindingsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -45,16 +45,17 @@ type RoleInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.Role, error)
 	List(opts v1.ListOptions) (*v1beta1.RoleList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Role, err error)
 	RoleExpansion
 }
 
 // roles implements RoleInterface
 type roles struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newRoles returns a Roles
@@ -64,9 +65,10 @@ func newRoles(c *RbacV1beta1Client, namespace string) *roles {
 
 func newRolesWithMultiTenancy(c *RbacV1beta1Client, namespace string, tenant string) *roles {
 	return &roles{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 }
 
 // Watch returns a watch.Interface that watches the requested roles.
-func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *roles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("roles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -45,16 +45,17 @@ type RoleBindingInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.RoleBinding, error)
 	List(opts v1.ListOptions) (*v1beta1.RoleBindingList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.RoleBinding, err error)
 	RoleBindingExpansion
 }
 
 // roleBindings implements RoleBindingInterface
 type roleBindings struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newRoleBindings returns a RoleBindings
@@ -64,9 +65,10 @@ func newRoleBindings(c *RbacV1beta1Client, namespace string) *roleBindings {
 
 func newRoleBindingsWithMultiTenancy(c *RbacV1beta1Client, namespace string, tenant string) *roleBindings {
 	return &roleBindings{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -104,19 +106,24 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 }
 
 // Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *roleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("rolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_priorityclass.go
@@ -70,10 +70,13 @@ func (c *FakePriorityClasses) List(opts v1.ListOptions) (result *schedulingv1.Pr
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested priorityClasses.
-func (c *FakePriorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested priorityClasses.
+func (c *FakePriorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(priorityclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
@@ -70,10 +70,13 @@ func (c *FakePriorityClasses) List(opts v1.ListOptions) (result *v1alpha1.Priori
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested priorityClasses.
-func (c *FakePriorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested priorityClasses.
+func (c *FakePriorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(priorityclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -44,20 +44,22 @@ type PriorityClassInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.PriorityClass, error)
 	List(opts v1.ListOptions) (*v1alpha1.PriorityClassList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.PriorityClass, err error)
 	PriorityClassExpansion
 }
 
 // priorityClasses implements PriorityClassInterface
 type priorityClasses struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newPriorityClasses returns a PriorityClasses
 func newPriorityClasses(c *SchedulingV1alpha1Client) *priorityClasses {
 	return &priorityClasses{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityCl
 }
 
 // Watch returns a watch.Interface that watches the requested priorityClasses.
-func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *priorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("priorityclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_priorityclass.go
@@ -70,10 +70,13 @@ func (c *FakePriorityClasses) List(opts v1.ListOptions) (result *v1beta1.Priorit
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested priorityClasses.
-func (c *FakePriorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested priorityClasses.
+func (c *FakePriorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(priorityclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -44,20 +44,22 @@ type PriorityClassInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.PriorityClass, error)
 	List(opts v1.ListOptions) (*v1beta1.PriorityClassList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.PriorityClass, err error)
 	PriorityClassExpansion
 }
 
 // priorityClasses implements PriorityClassInterface
 type priorityClasses struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newPriorityClasses returns a PriorityClasses
 func newPriorityClasses(c *SchedulingV1beta1Client) *priorityClasses {
 	return &priorityClasses{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1beta1.PriorityCla
 }
 
 // Watch returns a watch.Interface that watches the requested priorityClasses.
-func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *priorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("priorityclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
@@ -74,11 +74,14 @@ func (c *FakePodPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested podPresets.
-func (c *FakePodPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested podPresets.
+func (c *FakePodPresets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(podpresetsResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a podPreset and creates it.  Returns the server's representation of the podPreset, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
@@ -70,10 +70,13 @@ func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *storagev1.Storag
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested storageClasses.
-func (c *FakeStorageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested storageClasses.
+func (c *FakeStorageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_volumeattachment.go
@@ -73,11 +73,14 @@ func (c *FakeVolumeAttachments) List(opts v1.ListOptions) (result *storagev1.Vol
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested volumeAttachments.
-func (c *FakeVolumeAttachments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested volumeAttachments.
+func (c *FakeVolumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(volumeattachmentsResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -46,15 +46,16 @@ type VolumeAttachmentInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.VolumeAttachment, error)
 	List(opts metav1.ListOptions) (*v1.VolumeAttachmentList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VolumeAttachment, err error)
 	VolumeAttachmentExpansion
 }
 
 // volumeAttachments implements VolumeAttachmentInterface
 type volumeAttachments struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newVolumeAttachments returns a VolumeAttachments
@@ -64,8 +65,9 @@ func newVolumeAttachments(c *StorageV1Client) *volumeAttachments {
 
 func newVolumeAttachmentsWithMultiTenancy(c *StorageV1Client, tenant string) *volumeAttachments {
 	return &volumeAttachments{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }
 
@@ -102,18 +104,23 @@ func (c *volumeAttachments) List(opts metav1.ListOptions) (result *v1.VolumeAtta
 }
 
 // Watch returns a watch.Interface that watches the requested volumeAttachments.
-func (c *volumeAttachments) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *volumeAttachments) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Resource("volumeattachments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Resource("volumeattachments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_volumeattachment.go
@@ -73,11 +73,14 @@ func (c *FakeVolumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.Volu
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested volumeAttachments.
-func (c *FakeVolumeAttachments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested volumeAttachments.
+func (c *FakeVolumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(volumeattachmentsResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -46,15 +46,16 @@ type VolumeAttachmentInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.VolumeAttachment, error)
 	List(opts v1.ListOptions) (*v1alpha1.VolumeAttachmentList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.VolumeAttachment, err error)
 	VolumeAttachmentExpansion
 }
 
 // volumeAttachments implements VolumeAttachmentInterface
 type volumeAttachments struct {
-	client rest.Interface
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	te      string
 }
 
 // newVolumeAttachments returns a VolumeAttachments
@@ -64,8 +65,9 @@ func newVolumeAttachments(c *StorageV1alpha1Client) *volumeAttachments {
 
 func newVolumeAttachmentsWithMultiTenancy(c *StorageV1alpha1Client, tenant string) *volumeAttachments {
 	return &volumeAttachments{
-		client: c.RESTClient(),
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		te:      tenant,
 	}
 }
 
@@ -102,18 +104,23 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.VolumeAt
 }
 
 // Watch returns a watch.Interface that watches the requested volumeAttachments.
-func (c *volumeAttachments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *volumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Resource("volumeattachments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Resource("volumeattachments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -44,20 +44,22 @@ type CSIDriverInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.CSIDriver, error)
 	List(opts v1.ListOptions) (*v1beta1.CSIDriverList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.CSIDriver, err error)
 	CSIDriverExpansion
 }
 
 // cSIDrivers implements CSIDriverInterface
 type cSIDrivers struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newCSIDrivers returns a CSIDrivers
 func newCSIDrivers(c *StorageV1beta1Client) *cSIDrivers {
 	return &cSIDrivers{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *cSIDrivers) List(opts v1.ListOptions) (result *v1beta1.CSIDriverList, e
 }
 
 // Watch returns a watch.Interface that watches the requested cSIDrivers.
-func (c *cSIDrivers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *cSIDrivers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("csidrivers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("csidrivers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a cSIDriver and creates it.  Returns the server's representation of the cSIDriver, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -44,20 +44,22 @@ type CSINodeInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.CSINode, error)
 	List(opts v1.ListOptions) (*v1beta1.CSINodeList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.CSINode, err error)
 	CSINodeExpansion
 }
 
 // cSINodes implements CSINodeInterface
 type cSINodes struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newCSINodes returns a CSINodes
 func newCSINodes(c *StorageV1beta1Client) *cSINodes {
 	return &cSINodes{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *cSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, err e
 }
 
 // Watch returns a watch.Interface that watches the requested cSINodes.
-func (c *cSINodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *cSINodes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("csinodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("csinodes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a cSINode and creates it.  Returns the server's representation of the cSINode, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csidriver.go
@@ -70,10 +70,13 @@ func (c *FakeCSIDrivers) List(opts v1.ListOptions) (result *v1beta1.CSIDriverLis
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested cSIDrivers.
-func (c *FakeCSIDrivers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested cSIDrivers.
+func (c *FakeCSIDrivers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(csidriversResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a cSIDriver and creates it.  Returns the server's representation of the cSIDriver, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csinode.go
@@ -70,10 +70,13 @@ func (c *FakeCSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, e
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested cSINodes.
-func (c *FakeCSINodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested cSINodes.
+func (c *FakeCSINodes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(csinodesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a cSINode and creates it.  Returns the server's representation of the cSINode, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
@@ -70,10 +70,13 @@ func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageC
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested storageClasses.
-func (c *FakeStorageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested storageClasses.
+func (c *FakeStorageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_volumeattachment.go
@@ -73,11 +73,14 @@ func (c *FakeVolumeAttachments) List(opts v1.ListOptions) (result *v1beta1.Volum
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested volumeAttachments.
-func (c *FakeVolumeAttachments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested volumeAttachments.
+func (c *FakeVolumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewTenantWatchAction(volumeattachmentsResource, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -44,20 +44,22 @@ type StorageClassInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.StorageClass, error)
 	List(opts v1.ListOptions) (*v1beta1.StorageClassList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.StorageClass, err error)
 	StorageClassExpansion
 }
 
 // storageClasses implements StorageClassInterface
 type storageClasses struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newStorageClasses returns a StorageClasses
 func newStorageClasses(c *StorageV1beta1Client) *storageClasses {
 	return &storageClasses{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 }
 
 // Watch returns a watch.Interface that watches the requested storageClasses.
-func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *storageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("storageclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -372,32 +372,35 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		if len(r.filterBounds) > 0 {
 			options = appendFieldSelector(options, r.createHashkeyListOptions())
 		}
-		w, err := r.listerWatcher.Watch(options)
-		if err != nil {
-			switch err {
-			case io.EOF:
-				// watch closed normally
-			case io.ErrUnexpectedEOF:
-				klog.V(1).Infof("%s: Watch for %v closed with unexpected EOF: %v", r.name, r.expectedType, err)
-			default:
-				utilruntime.HandleError(fmt.Errorf("%s: Failed to watch %v: %v", r.name, r.expectedType, err))
-			}
-			// If this is "connection refused" error, it means that most likely apiserver is not responsive.
-			// It doesn't make sense to re-list all objects because most likely we will be able to restart
-			// watch where we ended.
-			// If that's the case wait and resend watch request.
-			if urlError, ok := err.(*url.Error); ok {
-				if opError, ok := urlError.Err.(*net.OpError); ok {
-					if errno, ok := opError.Err.(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
-						time.Sleep(time.Second)
-						continue
+		aggregatedWatcher := r.listerWatcher.Watch(options)
+		errs := aggregatedWatcher.GetErrors()
+		for _, err := range errs {
+			if err != nil {
+				switch err {
+				case io.EOF:
+					// watch closed normally
+				case io.ErrUnexpectedEOF:
+					klog.V(1).Infof("%s: Watch for %v closed with unexpected EOF: %v", r.name, r.expectedType, err)
+				default:
+					utilruntime.HandleError(fmt.Errorf("%s: Failed to watch %v: %v", r.name, r.expectedType, err))
+				}
+				// If this is "connection refused" error, it means that most likely apiserver is not responsive.
+				// It doesn't make sense to re-list all objects because most likely we will be able to restart
+				// watch where we ended.
+				// If that's the case wait and resend watch request.
+				if urlError, ok := err.(*url.Error); ok {
+					if opError, ok := urlError.Err.(*net.OpError); ok {
+						if errno, ok := opError.Err.(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
+							time.Sleep(time.Second)
+							continue
+						}
 					}
 				}
+				return nil
 			}
-			return nil
 		}
 
-		if err := r.watchHandler(w, &resourceVersion, resyncerrc, stopCh); err != nil {
+		if err := r.watchHandler(aggregatedWatcher, &resourceVersion, resyncerrc, stopCh); err != nil {
 			if err == errorResetRequested {
 				select {
 				case cancelCh <- struct{}{}:
@@ -430,7 +433,7 @@ func (r *Reflector) syncWith(items []runtime.Object, resourceVersion string) err
 }
 
 // watchHandler watches w and keeps *resourceVersion up to date.
-func (r *Reflector) watchHandler(w watch.Interface, resourceVersion *string, errc chan error, stopCh <-chan struct{}) error {
+func (r *Reflector) watchHandler(w watch.AggregatedWatchInterface, resourceVersion *string, errc chan error, stopCh <-chan struct{}) error {
 	start := r.clock.Now()
 	eventCount := 0
 

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -100,41 +101,44 @@ func (rw *RetryWatcher) send(event watch.Event) bool {
 // doReceive returns true when it is done, false otherwise.
 // If it is not done the second return value holds the time to wait before calling it again.
 func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
-	watcher, err := rw.watcherClient.Watch(metav1.ListOptions{
+	watcher := rw.watcherClient.Watch(metav1.ListOptions{
 		ResourceVersion: rw.lastResourceVersion,
 	})
+
 	// We are very unlikely to hit EOF here since we are just establishing the call,
 	// but it may happen that the apiserver is just shutting down (e.g. being restarted)
 	// This is consistent with how it is handled for informers
-	switch err {
-	case nil:
-		break
+	for _, err := range watcher.GetErrors() {
+		switch err {
+		case nil:
+			break
 
-	case io.EOF:
-		// watch closed normally
-		return false, 0
+		case io.EOF:
+			// watch closed normally
+			return false, 0
 
-	case io.ErrUnexpectedEOF:
-		klog.V(1).Infof("Watch closed with unexpected EOF: %v", err)
-		return false, 0
+		case io.ErrUnexpectedEOF:
+			klog.V(1).Infof("Watch closed with unexpected EOF: %v", err)
+			return false, 0
 
-	default:
-		msg := "Watch failed: %v"
-		if net.IsProbableEOF(err) {
-			klog.V(5).Infof(msg, err)
+		default:
+			msg := "Watch failed: %v"
+			if net.IsProbableEOF(err) {
+				klog.V(5).Infof(msg, err)
+				// Retry
+				return false, 0
+			}
+
+			klog.Errorf(msg, err)
 			// Retry
 			return false, 0
 		}
 
-		klog.Errorf(msg, err)
-		// Retry
-		return false, 0
-	}
-
-	if watcher == nil {
-		klog.Error("Watch returned nil watcher")
-		// Retry
-		return false, 0
+		if watcher == nil {
+			klog.Error("Watch returned nil watcher")
+			// Retry
+			return false, 0
+		}
 	}
 
 	ch := watcher.ResultChan()

--- a/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
@@ -89,7 +89,7 @@ func WaitForCertificate(ctx context.Context, client certificatesclient.Certifica
 			options.FieldSelector = fieldSelector
 			return client.List(options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			options.FieldSelector = fieldSelector
 			return client.Watch(options)
 		},

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -71,10 +71,13 @@ func (c *FakeClusterTestTypes) List(opts v1.ListOptions) (result *examplev1.Clus
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterTestTypes.
-func (c *FakeClusterTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterTestTypes.
+func (c *FakeClusterTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clustertesttypesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterTestType and creates it.  Returns the server's representation of the clusterTestType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -74,11 +74,14 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *examplev1.TestTypeLis
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(testtypesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -46,16 +46,17 @@ type TestTypeInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.TestType, error)
 	List(opts metav1.ListOptions) (*v1.TestTypeList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.TestType, err error)
 	TestTypeExpansion
 }
 
 // testTypes implements TestTypeInterface
 type testTypes struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newTestTypes returns a TestTypes
@@ -65,9 +66,10 @@ func newTestTypes(c *ExampleV1Client, namespace string) *testTypes {
 
 func newTestTypesWithMultiTenancy(c *ExampleV1Client, namespace string, tenant string) *testTypes {
 	return &testTypes{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 }
 
 // Watch returns a watch.Interface that watches the requested testTypes.
-func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
@@ -63,7 +63,7 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				}
 				return client.ExampleV1().ClusterTestTypes().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/informers/externalversions/example/v1/testtype.go
@@ -73,7 +73,7 @@ func NewFilteredTestTypeInformerWithMultiTenancy(client versioned.Interface, nam
 				}
 				return client.ExampleV1().TestTypesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/fake/fake_testtype.go
@@ -74,11 +74,14 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *example.TestTypeList,
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(testtypesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -46,16 +46,17 @@ type TestTypeInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*example.TestType, error)
 	List(opts v1.ListOptions) (*example.TestTypeList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *example.TestType, err error)
 	TestTypeExpansion
 }
 
 // testTypes implements TestTypeInterface
 type testTypes struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newTestTypes returns a TestTypes
@@ -65,9 +66,10 @@ func newTestTypes(c *ExampleClient, namespace string) *testTypes {
 
 func newTestTypesWithMultiTenancy(c *ExampleClient, namespace string, tenant string) *testTypes {
 	return &testTypes{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example.TestTypeList, err
 }
 
 // Watch returns a watch.Interface that watches the requested testTypes.
-func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *testTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_testtype.go
@@ -74,11 +74,14 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *example2.TestTypeList
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(testtypesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -74,11 +74,14 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *examplev1.TestTypeLis
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(testtypesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -46,16 +46,17 @@ type TestTypeInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.TestType, error)
 	List(opts metav1.ListOptions) (*v1.TestTypeList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.TestType, err error)
 	TestTypeExpansion
 }
 
 // testTypes implements TestTypeInterface
 type testTypes struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newTestTypes returns a TestTypes
@@ -65,9 +66,10 @@ func newTestTypes(c *ExampleV1Client, namespace string) *testTypes {
 
 func newTestTypesWithMultiTenancy(c *ExampleV1Client, namespace string, tenant string) *testTypes {
 	return &testTypes{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 }
 
 // Watch returns a watch.Interface that watches the requested testTypes.
-func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
@@ -74,11 +74,14 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *example2v1.TestTypeLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(testtypesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -46,16 +46,17 @@ type TestTypeInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.TestType, error)
 	List(opts metav1.ListOptions) (*v1.TestTypeList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.TestType, err error)
 	TestTypeExpansion
 }
 
 // testTypes implements TestTypeInterface
 type testTypes struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newTestTypes returns a TestTypes
@@ -65,9 +66,10 @@ func newTestTypes(c *SecondExampleV1Client, namespace string) *testTypes {
 
 func newTestTypesWithMultiTenancy(c *SecondExampleV1Client, namespace string, tenant string) *testTypes {
 	return &testTypes{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 }
 
 // Watch returns a watch.Interface that watches the requested testTypes.
-func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/externalversions/example/v1/testtype.go
@@ -73,7 +73,7 @@ func NewFilteredTestTypeInformerWithMultiTenancy(client versioned.Interface, nam
 				}
 				return client.ExampleV1().TestTypesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/externalversions/example2/v1/testtype.go
@@ -73,7 +73,7 @@ func NewFilteredTestTypeInformerWithMultiTenancy(client versioned.Interface, nam
 				}
 				return client.SecondExampleV1().TestTypesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example/internalversion/testtype.go
@@ -73,7 +73,7 @@ func NewFilteredTestTypeInformerWithMultiTenancy(client clientsetinternalversion
 				}
 				return client.Example().TestTypesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/internalversion/testtype.go
@@ -73,7 +73,7 @@ func NewFilteredTestTypeInformerWithMultiTenancy(client clientsetinternalversion
 				}
 				return client.SecondExample().TestTypesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -71,10 +71,13 @@ func (c *FakeClusterTestTypes) List(opts v1.ListOptions) (result *examplev1.Clus
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested clusterTestTypes.
-func (c *FakeClusterTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested clusterTestTypes.
+func (c *FakeClusterTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clustertesttypesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a clusterTestType and creates it.  Returns the server's representation of the clusterTestType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -74,11 +74,14 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *examplev1.TestTypeLis
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(testtypesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -46,16 +46,17 @@ type TestTypeInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.TestType, error)
 	List(opts metav1.ListOptions) (*v1.TestTypeList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.TestType, err error)
 	TestTypeExpansion
 }
 
 // testTypes implements TestTypeInterface
 type testTypes struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newTestTypes returns a TestTypes
@@ -65,9 +66,10 @@ func newTestTypes(c *ExampleV1Client, namespace string) *testTypes {
 
 func newTestTypesWithMultiTenancy(c *ExampleV1Client, namespace string, tenant string) *testTypes {
 	return &testTypes{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 }
 
 // Watch returns a watch.Interface that watches the requested testTypes.
-func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
@@ -74,11 +74,14 @@ func (c *FakeTestTypes) List(opts v1.ListOptions) (result *example2v1.TestTypeLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(testtypesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -46,16 +46,17 @@ type TestTypeInterface interface {
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (*v1.TestType, error)
 	List(opts metav1.ListOptions) (*v1.TestTypeList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.TestType, err error)
 	TestTypeExpansion
 }
 
 // testTypes implements TestTypeInterface
 type testTypes struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newTestTypes returns a TestTypes
@@ -65,9 +66,10 @@ func newTestTypes(c *SecondExampleV1Client, namespace string) *testTypes {
 
 func newTestTypesWithMultiTenancy(c *SecondExampleV1Client, namespace string, tenant string) *testTypes {
 	return &testTypes{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 }
 
 // Watch returns a watch.Interface that watches the requested testTypes.
-func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.

--- a/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/example/v1/clustertesttype.go
@@ -63,7 +63,7 @@ func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod
 				}
 				return client.ExampleV1().ClusterTestTypes().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/example/v1/testtype.go
@@ -73,7 +73,7 @@ func NewFilteredTestTypeInformerWithMultiTenancy(client versioned.Interface, nam
 				}
 				return client.ExampleV1().TestTypesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/informers/externalversions/example2/v1/testtype.go
@@ -73,7 +73,7 @@ func NewFilteredTestTypeInformerWithMultiTenancy(client versioned.Interface, nam
 				}
 				return client.SecondExampleV1().TestTypesWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -134,6 +134,8 @@ func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.
 		"GroupVersionKind":     c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupVersionKind"}),
 		"PatchType":            c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/types", Name: "PatchType"}),
 		"watchInterface":       c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "Interface"}),
+		"aggregatedWatcher":    c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "NewAggregatedWatcher"}),
+		"aggregatedWatchInterface": c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "AggregatedWatchInterface"}),
 		"DefaultTenant":        metav1.TenantDefault,
 
 		"NewRootListAction":              c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewRootListAction"}),
@@ -507,12 +509,15 @@ func (c *Fake$.type|publicPlural$) UpdateStatus($.type|private$ *$.type|raw$) (*
 `
 
 var watchTemplate = `
-// Watch returns a $.watchInterface|raw$ that watches the requested $.type|privatePlural$.
-func (c *Fake$.type|publicPlural$) Watch(opts $.ListOptions|raw$) ($.watchInterface|raw$, error) {
-	return c.Fake.
+// Watch returns a $.aggregatedWatchInterface|raw$ that watches the requested $.type|privatePlural$.
+func (c *Fake$.type|publicPlural$) Watch(opts $.ListOptions|raw$) $.aggregatedWatchInterface|raw$ {
+	aggWatch := $.aggregatedWatcher|raw$()
+	watcher, err := c.Fake.
 		$if .namespaced$InvokesWatch($.NewWatchAction|raw$WithMultiTenancy($.type|allLowercasePlural$Resource, c.ns, opts, c.te))$end$
 		$if .tenanted$InvokesWatch($.NewTenantWatchAction|raw$($.type|allLowercasePlural$Resource, opts, c.te))$end$
 		$if .clusterScoped$InvokesWatch($.NewRootWatchAction|raw$($.type|allLowercasePlural$Resource, opts))$end$
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 `
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -146,6 +146,8 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"GetOptions":           c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "GetOptions"}),
 		"PatchType":            c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/types", Name: "PatchType"}),
 		"watchInterface":       c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "Interface"}),
+		"aggregatedWatchInterface":        c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "AggregatedWatchInterface"}),
+		"aggregatedWatcher":    c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "NewAggregatedWatcher"}),
 		"RESTClientInterface":  c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
 		"schemeParameterCodec": c.Universe.Variable(types.Name{Package: filepath.Join(g.clientsetPackage, "scheme"), Name: "ParameterCodec"}),
 		"DefaultTenant":        metav1.TenantDefault,
@@ -334,7 +336,7 @@ var defaultVerbTemplates = map[string]string{
 	"deleteCollection": `DeleteCollection(options *$.DeleteOptions|raw$, listOptions $.ListOptions|raw$) error`,
 	"get":              `Get(name string, options $.GetOptions|raw$) (*$.resultType|raw$, error)`,
 	"list":             `List(opts $.ListOptions|raw$) (*$.resultType|raw$List, error)`,
-	"watch":            `Watch(opts $.ListOptions|raw$) ($.watchInterface|raw$, error)`,
+	"watch":            `Watch(opts $.ListOptions|raw$) $.aggregatedWatchInterface|raw$`,
 	"patch":            `Patch(name string, pt $.PatchType|raw$, data []byte, subresources ...string) (result *$.resultType|raw$, err error)`,
 }
 
@@ -378,6 +380,7 @@ var structNamespaceScoped = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
 	client $.RESTClientInterface|raw$
+	clients []$.RESTClientInterface|raw$
 	ns     string
 	te     string
 }
@@ -388,6 +391,7 @@ var structTenantScoped = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
 	client $.RESTClientInterface|raw$
+	clients []$.RESTClientInterface|raw$
 	te     string
 }
 `
@@ -397,6 +401,7 @@ var structClusterScoped = `
 // $.type|privatePlural$ implements $.type|public$Interface
 type $.type|privatePlural$ struct {
 	client $.RESTClientInterface|raw$
+	clients []$.RESTClientInterface|raw$
 }
 `
 
@@ -408,7 +413,8 @@ func new$.type|publicPlural$(c *$.GroupGoName$$.Version$Client, namespace string
 
 func new$.type|publicPlural$WithMultiTenancy(c *$.GroupGoName$$.Version$Client, namespace string, tenant string) *$.type|privatePlural$ {
 	return &$.type|privatePlural${
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 		ns:     namespace,
 		te:     tenant,
 	}
@@ -423,7 +429,8 @@ func new$.type|publicPlural$(c *$.GroupGoName$$.Version$Client) *$.type|privateP
 
 func new$.type|publicPlural$WithMultiTenancy(c *$.GroupGoName$$.Version$Client, tenant string) *$.type|privatePlural$ {
 	return &$.type|privatePlural${
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 		te:     tenant,
 	}
 }
@@ -433,7 +440,8 @@ var newStructClusterScoped = `
 // new$.type|publicPlural$ returns a $.type|publicPlural$
 func new$.type|publicPlural$(c *$.GroupGoName$$.Version$Client) *$.type|privatePlural$ {
 	return &$.type|privatePlural${
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 `
@@ -650,20 +658,25 @@ func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (resu
 
 var watchTemplate = `
 // Watch returns a $.watchInterface|raw$ that watches the requested $.type|privatePlural$.
-func (c *$.type|privatePlural$) Watch(opts $.ListOptions|raw$) ($.watchInterface|raw$, error) {
+func (c *$.type|privatePlural$) Watch(opts $.ListOptions|raw$) $.aggregatedWatchInterface|raw$ {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil{
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		$if .namespaced$Tenant(c.te).
-		Namespace(c.ns).$end$
-		$if .tenanted$Tenant(c.te).$end$
-		Resource("$.type|resource$").
-		VersionedParams(&opts, $.schemeParameterCodec|raw$).
-		Timeout(timeout).
-		Watch()	
+	aggWatch := $.aggregatedWatcher|raw$()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			$if .namespaced$Tenant(c.te).
+			Namespace(c.ns).$end$
+			$if .tenanted$Tenant(c.te).$end$
+			Resource("$.type|resource$").
+			VersionedParams(&opts, $.schemeParameterCodec|raw$).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 `
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -108,6 +108,7 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 		"v1ListOptions":                   c.Universe.Type(v1ListOptions),
 		"version":                         namer.IC(g.groupVersion.Version.String()),
 		"watchInterface":                  c.Universe.Type(watchInterface),
+		"aggregatedWatchInterface":        c.Universe.Type(aggregatedWatchInterface),
 		"DefaultTenant":                   metav1.TenantDefault,
 	}
 
@@ -226,7 +227,7 @@ func NewFiltered$.type|public$Informer(client $.clientSetInterface|raw$, resyncP
 				}
 				return client.$.group$$.version$().$.type|publicPlural$().List(options)
 			},
-			WatchFunc: func(options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
+			WatchFunc: func(options $.v1ListOptions|raw$) $.aggregatedWatchInterface|raw$ {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
@@ -257,7 +258,7 @@ func NewFiltered$.type|public$InformerWithMultiTenancy(client $.clientSetInterfa
 				}
 				return client.$.group$$.version$().$.type|publicPlural$WithMultiTenancy(tenant).List(options)
 			},
-			WatchFunc: func(options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
+			WatchFunc: func(options $.v1ListOptions|raw$) $.aggregatedWatchInterface|raw$ {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
@@ -288,7 +289,7 @@ func NewFiltered$.type|public$InformerWithMultiTenancy(client $.clientSetInterfa
 				}
 				return client.$.group$$.version$().$.type|publicPlural$WithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
+			WatchFunc: func(options $.v1ListOptions|raw$) $.aggregatedWatchInterface|raw$ {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
@@ -43,4 +43,5 @@ var (
 	metav1NamespaceAll          = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "NamespaceAll"}
 	metav1Object                = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "Object"}
 	watchInterface              = types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "Interface"}
+	aggregatedWatchInterface    = types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "AggregatedWatchInterface"}
 )

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake/fake_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake/fake_apiservice.go
@@ -70,10 +70,13 @@ func (c *FakeAPIServices) List(opts v1.ListOptions) (result *apiregistrationv1.A
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested aPIServices.
-func (c *FakeAPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested aPIServices.
+func (c *FakeAPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(apiservicesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -45,20 +45,22 @@ type APIServiceInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.APIService, error)
 	List(opts v1.ListOptions) (*v1beta1.APIServiceList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.APIService, err error)
 	APIServiceExpansion
 }
 
 // aPIServices implements APIServiceInterface
 type aPIServices struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newAPIServices returns a APIServices
 func newAPIServices(c *ApiregistrationV1beta1Client) *aPIServices {
 	return &aPIServices{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -93,17 +95,22 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList,
 }
 
 // Watch returns a watch.Interface that watches the requested aPIServices.
-func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *aPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("apiservices").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiservice.go
@@ -70,10 +70,13 @@ func (c *FakeAPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceL
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested aPIServices.
-func (c *FakeAPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested aPIServices.
+func (c *FakeAPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(apiservicesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/fake/fake_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/fake/fake_apiservice.go
@@ -70,10 +70,13 @@ func (c *FakeAPIServices) List(opts v1.ListOptions) (result *apiregistration.API
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested aPIServices.
-func (c *FakeAPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested aPIServices.
+func (c *FakeAPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(apiservicesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
@@ -63,7 +63,7 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 				}
 				return client.ApiregistrationV1().APIServices().List(options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
@@ -63,7 +63,7 @@ func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time
 				}
 				return client.ApiregistrationV1beta1().APIServices().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion/apiservice.go
@@ -63,7 +63,7 @@ func NewFilteredAPIServiceInformer(client internalclientset.Interface, resyncPer
 				}
 				return client.Apiregistration().APIServices().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_clusterid.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_clusterid.go
@@ -110,7 +110,7 @@ func (g *Cloud) watchClusterID(stop <-chan struct{}) {
 		},
 	}
 
-	listerWatcher := cache.NewListWatchFromClient(g.ClusterID.client.CoreV1().RESTClient(), "configmaps", UIDNamespace, fields.Everything())
+	listerWatcher := cache.NewListWatchFromClient(g.ClusterID.client.CoreV1(), "configmaps", UIDNamespace, fields.Everything())
 	var controller cache.Controller
 	g.ClusterID.store, controller = cache.NewInformer(newSingleObjectListerWatcher(listerWatcher, UIDConfigMapName), &v1.ConfigMap{}, updateFuncFrequency, mapEventHandler)
 
@@ -261,7 +261,7 @@ func (sow *singleObjListerWatcher) List(options metav1.ListOptions) (runtime.Obj
 	return sow.lw.List(options)
 }
 
-func (sow *singleObjListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+func (sow *singleObjListerWatcher) Watch(options metav1.ListOptions) watch.AggregatedWatchInterface {
 	options.FieldSelector = "metadata.name=" + sow.objectName
 	return sow.lw.Watch(options)
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
@@ -69,8 +69,11 @@ func (c *FakeNodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetr
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested nodeMetricses.
-func (c *FakeNodeMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested nodeMetricses.
+func (c *FakeNodeMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(nodemetricsesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
@@ -73,9 +73,12 @@ func (c *FakePodMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetric
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested podMetricses.
-func (c *FakePodMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested podMetricses.
+func (c *FakePodMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(podmetricsesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
@@ -39,19 +39,21 @@ type NodeMetricsesGetter interface {
 type NodeMetricsInterface interface {
 	Get(name string, options v1.GetOptions) (*v1alpha1.NodeMetrics, error)
 	List(opts v1.ListOptions) (*v1alpha1.NodeMetricsList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	NodeMetricsExpansion
 }
 
 // nodeMetricses implements NodeMetricsInterface
 type nodeMetricses struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newNodeMetricses returns a NodeMetricses
 func newNodeMetricses(c *MetricsV1alpha1Client) *nodeMetricses {
 	return &nodeMetricses{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -86,15 +88,20 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsL
 }
 
 // Watch returns a watch.Interface that watches the requested nodeMetricses.
-func (c *nodeMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *nodeMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("nodes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -40,15 +40,16 @@ type PodMetricsesGetter interface {
 type PodMetricsInterface interface {
 	Get(name string, options v1.GetOptions) (*v1alpha1.PodMetrics, error)
 	List(opts v1.ListOptions) (*v1alpha1.PodMetricsList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	PodMetricsExpansion
 }
 
 // podMetricses implements PodMetricsInterface
 type podMetricses struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newPodMetricses returns a PodMetricses
@@ -58,9 +59,10 @@ func newPodMetricses(c *MetricsV1alpha1Client, namespace string) *podMetricses {
 
 func newPodMetricsesWithMultiTenancy(c *MetricsV1alpha1Client, namespace string, tenant string) *podMetricses {
 	return &podMetricses{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -98,17 +100,22 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsLis
 }
 
 // Watch returns a watch.Interface that watches the requested podMetricses.
-func (c *podMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *podMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("pods").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
@@ -69,8 +69,11 @@ func (c *FakeNodeMetricses) List(opts v1.ListOptions) (result *v1beta1.NodeMetri
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested nodeMetricses.
-func (c *FakeNodeMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested nodeMetricses.
+func (c *FakeNodeMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(nodemetricsesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
@@ -73,9 +73,12 @@ func (c *FakePodMetricses) List(opts v1.ListOptions) (result *v1beta1.PodMetrics
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested podMetricses.
-func (c *FakePodMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested podMetricses.
+func (c *FakePodMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(podmetricsesResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/fake/fake_runtimeclass.go
@@ -70,10 +70,13 @@ func (c *FakeRuntimeClasses) List(opts v1.ListOptions) (result *v1alpha1.Runtime
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested runtimeClasses.
-func (c *FakeRuntimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested runtimeClasses.
+func (c *FakeRuntimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(runtimeclassesResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
@@ -44,20 +44,22 @@ type RuntimeClassInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.RuntimeClass, error)
 	List(opts v1.ListOptions) (*v1alpha1.RuntimeClassList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.RuntimeClass, err error)
 	RuntimeClassExpansion
 }
 
 // runtimeClasses implements RuntimeClassInterface
 type runtimeClasses struct {
-	client rest.Interface
+	client  rest.Interface
+	clients []rest.Interface
 }
 
 // newRuntimeClasses returns a RuntimeClasses
 func newRuntimeClasses(c *NodeV1alpha1Client) *runtimeClasses {
 	return &runtimeClasses{
-		client: c.RESTClient(),
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
 	}
 }
 
@@ -92,17 +94,22 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 }
 
 // Watch returns a watch.Interface that watches the requested runtimeClasses.
-func (c *runtimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Resource("runtimeclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Resource("runtimeclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.

--- a/staging/src/k8s.io/node-api/pkg/client/informers/externalversions/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/node-api/pkg/client/informers/externalversions/node/v1alpha1/runtimeclass.go
@@ -63,7 +63,7 @@ func NewFilteredRuntimeClassInformer(client versioned.Interface, resyncPeriod ti
 				}
 				return client.NodeV1alpha1().RuntimeClasses().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
@@ -70,10 +70,13 @@ func (c *FakeFischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested fischers.
-func (c *FakeFischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested fischers.
+func (c *FakeFischers) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(fischersResource, opts))
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a fischer and creates it.  Returns the server's representation of the fischer, and an error, if there is any.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
@@ -74,11 +74,14 @@ func (c *FakeFlunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested flunders.
-func (c *FakeFlunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested flunders.
+func (c *FakeFlunders) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(flundersResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
@@ -74,11 +74,14 @@ func (c *FakeFlunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, e
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested flunders.
-func (c *FakeFlunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested flunders.
+func (c *FakeFlunders) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(flundersResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -46,16 +46,17 @@ type FlunderInterface interface {
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1beta1.Flunder, error)
 	List(opts v1.ListOptions) (*v1beta1.FlunderList, error)
-	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Flunder, err error)
 	FlunderExpansion
 }
 
 // flunders implements FlunderInterface
 type flunders struct {
-	client rest.Interface
-	ns     string
-	te     string
+	client  rest.Interface
+	clients []rest.Interface
+	ns      string
+	te      string
 }
 
 // newFlunders returns a Flunders
@@ -65,9 +66,10 @@ func newFlunders(c *WardleV1beta1Client, namespace string) *flunders {
 
 func newFlundersWithMultiTenancy(c *WardleV1beta1Client, namespace string, tenant string) *flunders {
 	return &flunders{
-		client: c.RESTClient(),
-		ns:     namespace,
-		te:     tenant,
+		client:  c.RESTClient(),
+		clients: c.RESTClients(),
+		ns:      namespace,
+		te:      tenant,
 	}
 }
 
@@ -105,19 +107,24 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, err e
 }
 
 // Watch returns a watch.Interface that watches the requested flunders.
-func (c *flunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *flunders) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
-	return c.client.Get().
-		Tenant(c.te).
-		Namespace(c.ns).
-		Resource("flunders").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch()
+	aggWatch := watch.NewAggregatedWatcher()
+	for _, client := range c.clients {
+		watcher, err := client.Get().
+			Tenant(c.te).
+			Namespace(c.ns).
+			Resource("flunders").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Watch()
+		aggWatch.AddWatchInterface(watcher, err)
+	}
+	return aggWatch
 }
 
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
@@ -63,7 +63,7 @@ func NewFilteredFischerInformer(client versioned.Interface, resyncPeriod time.Du
 				}
 				return client.WardleV1alpha1().Fischers().List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
@@ -73,7 +73,7 @@ func NewFilteredFlunderInformerWithMultiTenancy(client versioned.Interface, name
 				}
 				return client.WardleV1alpha1().FlundersWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
@@ -73,7 +73,7 @@ func NewFilteredFlunderInformerWithMultiTenancy(client versioned.Interface, name
 				}
 				return client.WardleV1beta1().FlundersWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/fake/fake_foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/fake/fake_foo.go
@@ -74,11 +74,14 @@ func (c *FakeFoos) List(opts v1.ListOptions) (result *v1alpha1.FooList, err erro
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested foos.
-func (c *FakeFoos) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
+// Watch returns a watch.AggregatedWatchInterface that watches the requested foos.
+func (c *FakeFoos) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
+	aggWatch := watch.NewAggregatedWatcher()
+	watcher, err := c.Fake.
 		InvokesWatch(testing.NewWatchActionWithMultiTenancy(foosResource, c.ns, opts, c.te))
 
+	aggWatch.AddWatchInterface(watcher, err)
+	return aggWatch
 }
 
 // Create takes the representation of a foo and creates it.  Returns the server's representation of the foo, and an error, if there is any.

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
@@ -73,7 +73,7 @@ func NewFilteredFooInformerWithMultiTenancy(client versioned.Interface, namespac
 				}
 				return client.SamplecontrollerV1alpha1().FoosWithMultiTenancy(namespace, tenant).List(options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options v1.ListOptions) watch.AggregatedWatchInterface {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/test/utils/pod_store.go
+++ b/test/utils/pod_store.go
@@ -45,7 +45,7 @@ func NewPodStore(c clientset.Interface, namespace string, label labels.Selector,
 			obj, err := c.CoreV1().Pods(namespace).List(options)
 			return runtime.Object(obj), err
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options metav1.ListOptions) watch.AggregatedWatchInterface {
 			options.LabelSelector = label.String()
 			options.FieldSelector = field.String()
 			return c.CoreV1().Pods(namespace).Watch(options)


### PR DESCRIPTION
  . client builder & api store
  . kube controller manager
  . Kubelet/Kubemark
  . fake

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
