### PR TITLE
temporary workaround: tweak make quick-release NOT to build e2e.test

### DIFF
--- a/cluster/images/conformance/Dockerfile
+++ b/cluster/images/conformance/Dockerfile
@@ -1,4 +1,5 @@
 # Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
 FROM BASEIMAGE
 
 COPY ginkgo /usr/local/bin/
-COPY e2e.test /usr/local/bin/
+#COPY e2e.test /usr/local/bin/
 COPY kubectl /usr/local/bin/
 COPY run_e2e.sh /run_e2e.sh
 COPY cluster /kubernetes/cluster

--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -1,4 +1,5 @@
 # Copyright 2016 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,12 +45,12 @@ endif
 
 	cp ${GINKGO_BIN} ${TEMP_DIR}
 	cp ${KUBECTL_BIN} ${TEMP_DIR}
-	cp ${E2E_TEST_BIN} ${TEMP_DIR}
+	#cp ${E2E_TEST_BIN} ${TEMP_DIR}
 	cp -r ${CLUSTER_DIR} ${TEMP_DIR}/cluster
 
 	chmod a+rx ${TEMP_DIR}/ginkgo
 	chmod a+rx ${TEMP_DIR}/kubectl
-	chmod a+rx ${TEMP_DIR}/e2e.test
+	#chmod a+rx ${TEMP_DIR}/e2e.test
 
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -107,7 +107,7 @@ kube::golang::conformance_image_targets() {
   # NOTE: this contains cmd targets for kube::release::build_conformance_image
   local targets=(
     vendor/github.com/onsi/ginkgo/ginkgo
-    test/e2e/e2e.test
+    # test/e2e/e2e.test
     cmd/kubectl
   )
   echo "${targets[@]}"
@@ -262,7 +262,7 @@ kube::golang::test_targets() {
     cmd/genswaggertypedocs
     cmd/linkcheck
     vendor/github.com/onsi/ginkgo/ginkgo
-    test/e2e/e2e.test
+    # test/e2e/e2e.test
   )
   echo "${targets[@]}"
 }
@@ -291,9 +291,9 @@ kube::golang::server_test_targets() {
     vendor/github.com/onsi/ginkgo/ginkgo
   )
 
-  if [[ "${OSTYPE:-}" == "linux"* ]]; then
-    targets+=( test/e2e_node/e2e_node.test )
-  fi
+  #if [[ "${OSTYPE:-}" == "linux"* ]]; then
+    # targets+=( test/e2e_node/e2e_node.test )
+  #fi
 
   echo "${targets[@]}"
 }


### PR DESCRIPTION
as temporary workaround (before test code can be compiled without error), suppress make process to not to include e2e.test build and packaging.

Following command should be OK:
```
make quick-release
```