### PR TITLE
enables prometheus at kubemark test clusters

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -25,6 +25,38 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+function start-prometheus {
+  echo "configing prometheus-metrics"
+  cat <<EOF > /tmp/prometheus-metrics.yaml
+global:
+  scrape_interval: 10s
+scrape_configs:
+- job_name: collect-etcd
+  static_configs:
+  - targets: ['127.0.0.1:2382']
+- job_name: collect-k8s-api
+  static_configs:
+  - targets: ['127.0.0.1:8080']
+- job_name: collect-k8s-controllers
+  static_configs:
+  - targets: ['127.0.0.1:10252']
+- job_name: collect-k8s-sched
+  static_configs:
+  - targets: ['127.0.0.1:10251']
+EOF
+
+  cd /etc/srv/kubernetes
+
+  echo "downloading prometheus binary..."
+  local RELEASE="2.2.1"
+  wget https://github.com/prometheus/prometheus/releases/download/v${RELEASE}/prometheus-${RELEASE}.linux-amd64.tar.gz
+  tar xvf prometheus-${RELEASE}.linux-amd64.tar.gz
+  cd prometheus-${RELEASE}.linux-amd64/
+
+  echo "running prometheus service; log streamed to prometheus.log file"
+  nohup ./prometheus --config.file="/tmp/prometheus-metrics.yaml" --web.listen-address=":9090" --web.enable-admin-api > prometheus.log 2>&1 &
+}
+
 function setup-os-params {
   # Reset core_pattern. On GCI, the default core_pattern pipes the core dumps to
   # /sbin/crash_reporter which is more restrictive in saving crash dumps. So for
@@ -2905,6 +2937,9 @@ function main() {
     start-cluster-autoscaler
     start-lb-controller
     update-legacy-addon-node-labels &
+
+    echo "starting prometheus and scraping metrics from etcd & API server..."
+    start-prometheus
   else
     if [[ "${KUBE_PROXY_DAEMONSET:-}" != "true" ]]; then
       start-kube-proxy
@@ -2916,6 +2951,7 @@ function main() {
   reset-motd
   prepare-mounter-rootfs
   modprobe configs
+
   echo "Done for the configuration for kubernetes"
 }
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1125,6 +1125,7 @@ function build-linux-kube-env {
   rm -f ${file}
   cat >$file <<EOF
 CLUSTER_NAME: $(yaml-quote ${CLUSTER_NAME})
+ENABLE_APISERVER_INSECURE_PORT: $(yaml-quote ${ENABLE_APISERVER_INSECURE_PORT:-true})
 ENV_TIMESTAMP: $(yaml-quote $(date -u +%Y-%m-%dT%T%z))
 INSTANCE_PREFIX: $(yaml-quote ${INSTANCE_PREFIX})
 NODE_INSTANCE_PREFIX: $(yaml-quote ${NODE_INSTANCE_PREFIX})
@@ -2696,6 +2697,12 @@ function create-etcd-apiserver-certs {
 
 function create-master() {
   echo "Starting master and configuring firewalls"
+  gcloud compute firewall-rules create "${MASTER_NAME}-prometheus" \
+    --project "${NETWORK_PROJECT}" \
+    --network "${NETWORK}" \
+    --source-ranges "0.0.0.0/0" \
+    --allow tcp:9090 &
+
   gcloud compute firewall-rules create "${MASTER_NAME}-https" \
     --project "${NETWORK_PROJECT}" \
     --network "${NETWORK}" \
@@ -3610,6 +3617,8 @@ function kube-down() {
   if [[ "${REMAINING_MASTER_COUNT}" -eq 0 ]]; then
     # Delete firewall rule for the master, etcd servers, and nodes.
     delete-firewall-rules "${MASTER_NAME}-https" "${MASTER_NAME}-etcd" "${NODE_TAG}-all" "${MASTER_NAME}-konnectivity-server"
+    delete-firewall-rules "${MASTER_NAME}-prometheus"
+
     # Delete the master's reserved IP
     if gcloud compute addresses describe "${MASTER_NAME}-ip" --region "${REGION}" --project "${PROJECT}" &>/dev/null; then
       gcloud compute addresses delete \


### PR DESCRIPTION
**What this PR does / why we need it**:
It enables prometheus server at kubemark test clusters to collect metrics of etcd, api server, KCM and scheduler.
It is verified working for k8s 1.18.5