### PR TITLE
enables prometheus server at kubemark test for k8s v1.2x

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -58,6 +58,47 @@ function append-param-if-not-present {
   echo "${params}"
 }
 
+function start-prometheus {
+  echo "configing prometheus-metrics"
+  cat <<EOF > /tmp/prometheus-metrics.yaml
+global:
+  scrape_interval: 10s
+scrape_configs:
+- job_name: collect-etcd
+  static_configs:
+  - targets: ['127.0.0.1:2382']
+- job_name: collect-k8s-api
+  scheme: https
+  bearer_token: "${KUBE_BEARER_TOKEN}"
+  tls_config:
+    insecure_skip_verify: true
+  static_configs:
+  - targets: ['127.0.0.1:443']
+- job_name: collect-k8s-controllers
+  scheme: https
+  bearer_token: "${KUBE_BEARER_TOKEN}"
+  tls_config:
+    insecure_skip_verify: true
+  static_configs:
+  - targets: ['127.0.0.1:10257']
+- job_name: collect-k8s-sched
+  static_configs:
+  - targets: ['127.0.0.1:10251']
+EOF
+
+  pushd /etc/srv/kubernetes
+
+  echo "downloading prometheus binary..."
+  local RELEASE="2.2.1"
+  wget https://github.com/prometheus/prometheus/releases/download/v${RELEASE}/prometheus-${RELEASE}.linux-amd64.tar.gz
+  tar xvf prometheus-${RELEASE}.linux-amd64.tar.gz
+  cd prometheus-${RELEASE}.linux-amd64/
+
+  echo "running prometheus service; log streamed to prometheus.log file"
+  nohup ./prometheus --config.file="/tmp/prometheus-metrics.yaml" --web.listen-address=":9090" --web.enable-admin-api > prometheus.log 2>&1 &
+  popd
+}
+
 function setup-os-params {
   # Reset core_pattern. On GCI, the default core_pattern pipes the core dumps to
   # /sbin/crash_reporter which is more restrictive in saving crash dumps. So for
@@ -3246,6 +3287,7 @@ function main() {
     start-cluster-autoscaler
     start-lb-controller
     update-legacy-addon-node-labels &
+    start-prometheus
   else
     if [[ "${KUBE_PROXY_DAEMONSET:-}" != "true" ]] && [[ "${KUBE_PROXY_DISABLE:-}" != "true" ]]; then
       start-kube-proxy


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR enables prometheus server at kubemark test clusters, collecting metrics from etcd, https-mode api server, KCM and scheduler. It is verified working with k8s v1.21.
